### PR TITLE
[Helm] Load YAMLs from Files in ConfigMap for Helm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .history/
+charts/lunar-proxy/policies.yaml
+charts/lunar-proxy/flows
+charts/lunar-proxy/quotas

--- a/charts/lunar-proxy/templates/configmap.yaml
+++ b/charts/lunar-proxy/templates/configmap.yaml
@@ -12,9 +12,12 @@ metadata:
     release: {{ .Release.Name | quote }}
 data:
   policies.yaml: |
-
-    ---
-    {{- toYaml .Values.policies | nindent 4 }}
+    {{- if .Files.Get "policies.yaml" }}
+      {{ .Files.Get "policies.yaml" | nindent 4 }}
+    {{- else }}
+      ---
+      {{ toYaml .Values.policies | nindent 4 }}
+    {{- end }}
 
 immutable: false
 {{- end -}}
@@ -31,10 +34,25 @@ metadata:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
 data:
-{{- range $key, $value := .Values.flows }}
-  {{ $key }}: |
-    {{ $value | nindent 4 }}
-{{- end }}
+  {{- $flowsPath := .Values.flowsPath }}
+  {{- $yamlFiles := .Files.Glob (printf "%s/*.yaml" $flowsPath) }}
+  {{- $ymlFiles := .Files.Glob (printf "%s/*.yml" $flowsPath) }}
+  {{- $files := append $yamlFiles $ymlFiles }}
+
+  {{- if $files }}
+    {{- range $file := $files }}
+    {{ base $file.Path }}: |
+      {{ .Files.Get $file.Path | nindent 4 }}
+    {{- end }}
+  {{- else }}
+    # Fallback to the original values.yaml-based values if no .yaml/.yml files found
+    {{- range $key, $value := .Values.flows }}
+      {{ $key }}: |
+        {{ $value | nindent 4 }}
+    {{- end }}
+  {{- end }}
+
+
 immutable: false
 ---
 apiVersion: v1
@@ -48,9 +66,22 @@ metadata:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
 data:
-{{- range $key, $value := .Values.quotas }}
-  {{ $key }}: |
-    {{ $value | nindent 4 }}
-{{- end }}
+  {{- $flowsPath := .Values.flowsPath }}
+  {{- $yamlFiles := .Files.Glob (printf "%s/*.yaml" $flowsPath) }}
+  {{- $ymlFiles := .Files.Glob (printf "%s/*.yml" $flowsPath) }}
+  {{- $files := append $yamlFiles $ymlFiles }}
+
+  {{- if $files }}
+    {{- range $file := $files }}
+    {{ base $file.Path }}: |
+      {{ .Files.Get $file.Path | nindent 4 }}
+    {{- end }}
+  {{- else }}
+    # Fallback to the original values.yaml-based values if no .yaml/.yml files found
+    {{- range $key, $value := .Values.quotas }}
+      {{ $key }}: |
+        {{ $value | nindent 4 }}
+    {{- end }}    
+  {{- end }}
 immutable: false
 {{- end -}}

--- a/charts/lunar-proxy/templates/configmap.yaml
+++ b/charts/lunar-proxy/templates/configmap.yaml
@@ -13,10 +13,10 @@ metadata:
 data:
   policies.yaml: |
     {{- if .Files.Get "policies.yaml" }}
-      {{ .Files.Get "policies.yaml" | nindent 4 }}
+      {{ .Files.Get "policies.yaml" | nindent 6 }}
     {{- else }}
       ---
-      {{ toYaml .Values.policies | nindent 4 }}
+      {{ toYaml .Values.policies | nindent 6 }}
     {{- end }}
 
 immutable: false
@@ -34,18 +34,16 @@ metadata:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
 data:
-  {{- $flowsPath := .Values.flowsPath }}
-  {{- $yamlFiles := .Files.Glob (printf "%s/*.yaml" $flowsPath) }}
-  {{- $ymlFiles := .Files.Glob (printf "%s/*.yml" $flowsPath) }}
-  {{- $files := append $yamlFiles $ymlFiles }}
+  {{- $flowsPath := .Values.configPaths.flows }}
+  {{- $files := .Files.Glob (printf "%s/*.yaml" $flowsPath) }}
 
   {{- if $files }}
-    {{- range $file := $files }}
-    {{ base $file.Path }}: |
-      {{ .Files.Get $file.Path | nindent 4 }}
+    {{- range $file, $content := $files }}
+    {{ base $file }}: |
+      {{ $content | toString | trim | nindent 6 }}
     {{- end }}
   {{- else }}
-    # Fallback to the original values.yaml-based values if no .yaml/.yml files found
+    # Fallback to the original values.yaml-based values if no .yaml files found
     {{- range $key, $value := .Values.flows }}
       {{ $key }}: |
         {{ $value | nindent 4 }}
@@ -66,18 +64,16 @@ metadata:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
 data:
-  {{- $flowsPath := .Values.flowsPath }}
-  {{- $yamlFiles := .Files.Glob (printf "%s/*.yaml" $flowsPath) }}
-  {{- $ymlFiles := .Files.Glob (printf "%s/*.yml" $flowsPath) }}
-  {{- $files := append $yamlFiles $ymlFiles }}
+  {{- $flowsPath := .Values.configPaths.quotas }}
+  {{- $files := .Files.Glob (printf "%s/*.yaml" $flowsPath) }}
 
   {{- if $files }}
-    {{- range $file := $files }}
-    {{ base $file.Path }}: |
-      {{ .Files.Get $file.Path | nindent 4 }}
+    {{- range $file, $content := $files }}
+    {{ base $file }}: |
+      {{ $content | toString | trim | nindent 6 }}
     {{- end }}
   {{- else }}
-    # Fallback to the original values.yaml-based values if no .yaml/.yml files found
+    # Fallback to the original values.yaml-based values if no .yaml files found
     {{- range $key, $value := .Values.quotas }}
       {{ $key }}: |
         {{ $value | nindent 4 }}

--- a/charts/lunar-proxy/values.yaml
+++ b/charts/lunar-proxy/values.yaml
@@ -187,9 +187,9 @@ policies:
       file_dir: "/var/log/lunar-proxy"
       file_name: "output.log"
 
-configDir:
-  flows: "/flows"
-  quotas: "/quotas"
+configPaths:
+  flows: "flows"
+  quotas: "quotas"
   
 # ==== Example of flows and quotas: ====
 # flows:

--- a/charts/lunar-proxy/values.yaml
+++ b/charts/lunar-proxy/values.yaml
@@ -187,6 +187,10 @@ policies:
       file_dir: "/var/log/lunar-proxy"
       file_name: "output.log"
 
+configDir:
+  flows: "/flows"
+  quotas: "/quotas"
+  
 # ==== Example of flows and quotas: ====
 # flows:
 #   rate_limit_flow.yaml: |


### PR DESCRIPTION
This PR allows our Helm Chart users to supply flow configuration files - and `policies.yaml` for those users - instead of editing `values.yaml` directly with the content of those files. This is much more ergonomic from a UX point-of-view.

Users may specify the directory name for `flows` and `quotas` (for now), and the Chart will load any `.yaml` file under that supplied directory, for flows and quotas, respectively.

I deployed the chart with some files, both with flows enabled and without, to verify it's working.