### PR TITLE
Read YAML files from users configmaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .history/
+/charts/lunar-proxy/override-values.yaml
+/charts/lunar-proxy/flows
+/charts/lunar-proxy/quotas
+/charts/lunar-proxy/policies.yaml

--- a/charts/lunar-proxy/README.md
+++ b/charts/lunar-proxy/README.md
@@ -1,0 +1,26 @@
+# Lunar Proxy Helm Chart
+
+In order to use Lunar Flows, it is required to define configmaps for flows and quotas.
+You may create them with any name you desire:
+
+```bash
+kubectl create configmap my-flows-config --from-file=./flows/
+kubectl create configmap my-quotas-config --from-file=./quotas/
+```
+Note that the `--from-file` attribute points to a full directory, under which your flows/quota YAMLs are expected to be found.
+
+Then, prepare a `values-override.yaml` (or similar) to allow installing/upgrading the chart properly:
+
+```yaml
+lunarStreamsEnabled: true
+configMapNames:
+  flows: flows-config-test
+  quotas: quotas-config-test
+```
+
+And finally, install/upgrade the chart:
+```bash
+helm install my-proxy lunar/lunar-proxy -f ./override-values.yaml
+```
+
+You may also override values inline within the `helm install` command, if preferred.

--- a/charts/lunar-proxy/templates/configmap.yaml
+++ b/charts/lunar-proxy/templates/configmap.yaml
@@ -11,11 +11,14 @@ metadata:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
 data:
+  {{- if .Values.configMapNames.policies }}
+  # No need to define data here; it will be provided via the external ConfigMap
+  {{- else }}
   policies.yaml: |
 
     ---
     {{- toYaml .Values.policies | nindent 4 }}
-
+  {{- end}}
 immutable: false
 {{- end -}}
 {{- if .Values.lunarStreamsEnabled }}
@@ -31,9 +34,13 @@ metadata:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
 data:
+{{- if .Values.configMapNames.flows }}
+  # No need to define data here; it will be provided via the external ConfigMap
+{{- else }}
 {{- range $key, $value := .Values.flows }}
   {{ $key }}: |
     {{ $value | nindent 4 }}
+{{- end }}
 {{- end }}
 immutable: false
 ---
@@ -48,9 +55,13 @@ metadata:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
 data:
+{{- if .Values.configMapNames.quotas }}
+  # No need to define data here; it will be provided via the external ConfigMap
+{{- else }}
 {{- range $key, $value := .Values.quotas }}
   {{ $key }}: |
     {{ $value | nindent 4 }}
 {{- end }}
+{{- end }}
 immutable: false
-{{- end -}}
+{{- end }}

--- a/charts/lunar-proxy/templates/deployment.yaml
+++ b/charts/lunar-proxy/templates/deployment.yaml
@@ -128,12 +128,32 @@ spec:
       {{- end }}
       volumes:
       {{- if .Values.lunarStreamsEnabled }}
+      {{- if .Values.configMapNames.flows }}
+        - configMap:
+            name: {{ .Values.configMapNames.flows }}
+          name: flows      
+      {{- else }}
         - configMap:
             name: flows
           name: flows
+      {{- end }}
+      {{- if .Values.configMapNames.quotas }}
+        - configMap:
+            name: {{ .Values.configMapNames.quotas }}
+          name: quotas      
+      {{- else }}
         - configMap:
             name: quotas
           name: quotas
+      {{- end }}
+      {{- else }} # i.e. lunarStreamsEnabled is false
+      {{- if .Values.configMapNames.policies }}
+        - configMap:
+            items:
+              - key: policies.yaml
+                path: policies.yaml
+            name: {{ .Values.configMapNames.policies }}
+          name: policies      
       {{- else }}
         - configMap:
             items:
@@ -141,4 +161,5 @@ spec:
                 path: policies.yaml
             name: policies.yaml
           name: policies
+      {{- end  }}
       {{- end }}

--- a/charts/lunar-proxy/values.schema.json
+++ b/charts/lunar-proxy/values.schema.json
@@ -15,9 +15,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "repository"
-      ],
+      "required": ["repository"],
       "additionalProperties": false
     },
     "imagePullSecrets": {
@@ -44,9 +42,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "create"
-      ],
+      "required": ["create"],
       "additionalProperties": true
     },
     "livenessProbe": {
@@ -90,10 +86,7 @@
       "type": "object"
     },
     "env": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "telemetryEnabled": {
       "type": "boolean"
@@ -102,22 +95,13 @@
       "type": "string"
     },
     "tenantName": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "awsAccessKeyId": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "awsSecretAccessKey": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "lunarManaged": {
       "type": "boolean"
@@ -144,10 +128,7 @@
           "type": "object"
         }
       },
-      "required": [
-        "type",
-        "port"
-      ],
+      "required": ["type", "port"],
       "additionalProperties": false
     },
     "resources": {
@@ -198,10 +179,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "path",
-                  "pathType"
-                ]
+                "required": ["path", "pathType"]
               }
             }
           }
@@ -277,9 +255,21 @@
           }
         }
       },
-      "required": [
-        "enabled"
-      ]
+      "required": ["enabled"]
+    },
+    "configMapNames": {
+      "type": "object",
+      "properties": {
+        "flows": {
+          "type": "string"
+        },
+        "quotas": {
+          "type": "string"
+        },
+        "policies": {
+          "type": "string"
+        }
+      }
     },
     "policies": {
       "type": "object",

--- a/charts/lunar-proxy/values.yaml
+++ b/charts/lunar-proxy/values.yaml
@@ -179,6 +179,11 @@ serviceMonitor:
 
   targetLabels: []
 
+configMapNames:
+  policies: ""
+  flows: ""
+  quotas: ""
+
 policies:
   global: {}
   endpoints: []


### PR DESCRIPTION
This PR allows users to supply flows, quotas or policies config via a custom config map:
```
kubectl create configmap flows-config-test --from-file=./charts/lunar-proxy/flows/ -n webapp
```
```
kubectl create configmap quotas-config-test --from-file=./charts/lunar-proxy/quotas/ -n webapp
```
or
```
kubectl create configmap policies-config-test --from-file=./charts/lunar-proxy/policies.yaml -n webapp
```
And then override `values.yaml` with the configmaps names:
```
helm install proxy-test ./charts/lunar-proxy --set configMapNames.flows="flows-config-test" --namespace webapp
```
(`helm upgrade` will work the same of course)

Note that the configmaps for flows and quotas are directed at a full folder while policies maps to a single file.

Backward compatibility is retained by detecting if `configMapNames.flows` / `configMapNames.quotas` / `configMapNames.policies` were defined - each separately. 