### PR TITLE
Expose Values for Configuring Metrics Export to DataDog + Support Mounting metric.yaml in Helm Chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .history/
+flows/
+quotas/
+override-values.yaml
+policies.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .history/
 flows/
 quotas/
+root/
 override-values.yaml
 policies.yaml

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["datadoghq", "openmetrics"]
+}

--- a/charts/lunar-proxy/templates/configmap.yaml
+++ b/charts/lunar-proxy/templates/configmap.yaml
@@ -54,3 +54,21 @@ data:
 {{- end }}
 immutable: false
 {{- end -}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metrics.yaml
+  namespace: {{ default .Release.Namespace }}
+  labels:
+    app: "{{ include "lunar-proxy.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+data:
+  metrics.yaml: |
+
+    ---
+    {{- toYaml .Values.metrics | nindent 4 }}
+
+immutable: false

--- a/charts/lunar-proxy/templates/deployment.yaml
+++ b/charts/lunar-proxy/templates/deployment.yaml
@@ -13,10 +13,25 @@ spec:
       {{- include "lunar-proxy.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
+        {{- if .Values.metrics.datadog.enabled }}
+        ad.datadoghq.com/lunar-proxy.checks: |
+          {
+            "openmetrics": {
+              "init_config": {},
+              "instances": [
+                {
+                  "openmetrics_endpoint": "http://%%host%%:{{ .Values.serviceMonitor.port }}/metrics",
+                  "namespace": "{{ .Values.metrics.datadog.namespace }}",
+                  "metrics": {{ toJson .Values.metrics.datadog.includedMetrics }}
+                }
+              ]
+            }
+          }
+        {{- end }}
       labels:
         {{- include "lunar-proxy.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/lunar-proxy/templates/deployment.yaml
+++ b/charts/lunar-proxy/templates/deployment.yaml
@@ -106,6 +106,8 @@ spec:
           {{- end }}
           volumeMounts:
           {{- if .Values.lunarStreamsEnabled }}
+            - mountPath: /etc/lunar-proxy
+              name: metrics
             - mountPath: /etc/lunar-proxy/flows
               name: flows
             - mountPath: /etc/lunar-proxy/quotas
@@ -134,6 +136,13 @@ spec:
         - configMap:
             name: quotas
           name: quotas
+        - configMap:
+            items:
+              - key: metrics.yaml
+                path: metrics.yaml
+            name: policies.yaml
+          name: metrics
+
       {{- else }}
         - configMap:
             items:

--- a/charts/lunar-proxy/values.schema.json
+++ b/charts/lunar-proxy/values.schema.json
@@ -15,9 +15,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "repository"
-      ],
+      "required": ["repository"],
       "additionalProperties": false
     },
     "imagePullSecrets": {
@@ -44,9 +42,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "create"
-      ],
+      "required": ["create"],
       "additionalProperties": true
     },
     "livenessProbe": {
@@ -83,6 +79,28 @@
     "podAnnotations": {
       "type": "object"
     },
+    "metrics": {
+      "type": "object",
+      "properties": {
+        "datadog": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "namespace": {
+              "type": "string"
+            },
+            "includedMetrics": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
     "podSecurityContext": {
       "type": "object"
     },
@@ -90,10 +108,7 @@
       "type": "object"
     },
     "env": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "telemetryEnabled": {
       "type": "boolean"
@@ -102,22 +117,13 @@
       "type": "string"
     },
     "tenantName": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "awsAccessKeyId": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "awsSecretAccessKey": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "lunarManaged": {
       "type": "boolean"
@@ -147,10 +153,7 @@
           "type": "object"
         }
       },
-      "required": [
-        "type",
-        "port"
-      ],
+      "required": ["type", "port"],
       "additionalProperties": false
     },
     "resources": {
@@ -201,10 +204,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "path",
-                  "pathType"
-                ]
+                "required": ["path", "pathType"]
               }
             }
           }
@@ -280,9 +280,7 @@
           }
         }
       },
-      "required": [
-        "enabled"
-      ]
+      "required": ["enabled"]
     },
     "configMapNames": {
       "type": "object",

--- a/charts/lunar-proxy/values.yaml
+++ b/charts/lunar-proxy/values.yaml
@@ -14,7 +14,20 @@ fullnameOverride: ""
 
 replicaCount: 1
 
-podAnnotations: {}
+podAnnotations:
+  ad.datadoghq.com/lunar-proxy.checks: |
+    {
+      "openmetrics": {
+        "init_config": {},
+        "instances": [
+          {
+            "openmetrics_endpoint": "http://%%host%%:3000/metrics",
+            "namespace": "eliav-test",
+            "metrics": [".*"]
+          }
+        ]
+      }
+    }      
 
 lunarAPIKey: null # Set the API key directly
 lunarAPIKeySecretName: null # Set the API key from a secret (key must be named lunarAPIKey)

--- a/charts/lunar-proxy/values.yaml
+++ b/charts/lunar-proxy/values.yaml
@@ -22,7 +22,7 @@ podAnnotations:
         "instances": [
           {
             "openmetrics_endpoint": "http://%%host%%:3000/metrics",
-            "namespace": "eliav-test",
+            "namespace": "tal-test",
             "metrics": [".*"]
           }
         ]

--- a/charts/lunar-proxy/values.yaml
+++ b/charts/lunar-proxy/values.yaml
@@ -14,20 +14,15 @@ fullnameOverride: ""
 
 replicaCount: 1
 
-podAnnotations:
-  ad.datadoghq.com/lunar-proxy.checks: |
-    {
-      "openmetrics": {
-        "init_config": {},
-        "instances": [
-          {
-            "openmetrics_endpoint": "http://%%host%%:3000/metrics",
-            "namespace": "tal-test",
-            "metrics": [".*"]
-          }
-        ]
-      }
-    }      
+podAnnotations: {}
+
+metrics:
+  datadog:
+    enabled: false  # Users can set this to true to enable Datadog metrics collection
+    namespace: "lunar_proxy"  # Default namespace for metrics; users can override as needed
+    includedMetrics: # List of metrics to collect; default is all metrics
+      - ".*" 
+
 
 lunarAPIKey: null # Set the API key directly
 lunarAPIKeySecretName: null # Set the API key from a secret (key must be named lunarAPIKey)

--- a/index.yaml
+++ b/index.yaml
@@ -222,6 +222,26 @@ entries:
     - https://github.com/TheLunarCompany/proxy-helm-chart/releases/download/lunar-proxy-v0.10.14-beta-c818766/lunar-proxy-v0.10.14-beta-c818766.tgz
     version: v0.10.14-beta-c818766
   - apiVersion: v2
+    appVersion: v0.10.14-beta-c40882d
+    created: "2024-10-28T17:33:48.699887757Z"
+    description: A Helm chart for Kubernetes
+    digest: 690f88a0be6c8a9b1392a7abbff286d5cafeaf426f127c69f3279d90156838be
+    name: lunar-proxy
+    type: application
+    urls:
+    - https://github.com/TheLunarCompany/proxy-helm-chart/releases/download/lunar-proxy-v0.10.14-beta-c40882d/lunar-proxy-v0.10.14-beta-c40882d.tgz
+    version: v0.10.14-beta-c40882d
+  - apiVersion: v2
+    appVersion: v0.10.14-beta-bd2f785
+    created: "2024-10-27T18:25:59.588788995Z"
+    description: A Helm chart for Kubernetes
+    digest: 92298dcde08c04c7eff2832c5c424578bbe5ac19080da71094e9a70db4fa6794
+    name: lunar-proxy
+    type: application
+    urls:
+    - https://github.com/TheLunarCompany/proxy-helm-chart/releases/download/lunar-proxy-v0.10.14-beta-bd2f785/lunar-proxy-v0.10.14-beta-bd2f785.tgz
+    version: v0.10.14-beta-bd2f785
+  - apiVersion: v2
     appVersion: v0.10.14-beta-b8fd734
     created: "2024-10-16T07:43:04.363013694Z"
     description: A Helm chart for Kubernetes
@@ -262,6 +282,16 @@ entries:
     - https://github.com/TheLunarCompany/proxy-helm-chart/releases/download/lunar-proxy-v0.10.14-beta-b51994b/lunar-proxy-v0.10.14-beta-b51994b.tgz
     version: v0.10.14-beta-b51994b
   - apiVersion: v2
+    appVersion: v0.10.14-beta-b4f5642
+    created: "2024-10-22T14:39:03.26580126Z"
+    description: A Helm chart for Kubernetes
+    digest: 6515c13baeb30a4e4835a78614f47633b26dcc5d68db1163dc3357df9c1a725b
+    name: lunar-proxy
+    type: application
+    urls:
+    - https://github.com/TheLunarCompany/proxy-helm-chart/releases/download/lunar-proxy-v0.10.14-beta-b4f5642/lunar-proxy-v0.10.14-beta-b4f5642.tgz
+    version: v0.10.14-beta-b4f5642
+  - apiVersion: v2
     appVersion: v0.10.14-beta-afae9e0
     created: "2024-10-16T08:11:50.28489279Z"
     description: A Helm chart for Kubernetes
@@ -272,6 +302,16 @@ entries:
     - https://github.com/TheLunarCompany/proxy-helm-chart/releases/download/lunar-proxy-v0.10.14-beta-afae9e0/lunar-proxy-v0.10.14-beta-afae9e0.tgz
     version: v0.10.14-beta-afae9e0
   - apiVersion: v2
+    appVersion: v0.10.14-beta-adafa49
+    created: "2024-10-29T13:56:05.449593278Z"
+    description: A Helm chart for Kubernetes
+    digest: b59ccc3ca2eae491b9a72d2e5054ea0aca1ea884d0d7be1076d1e34b12b81b15
+    name: lunar-proxy
+    type: application
+    urls:
+    - https://github.com/TheLunarCompany/proxy-helm-chart/releases/download/lunar-proxy-v0.10.14-beta-adafa49/lunar-proxy-v0.10.14-beta-adafa49.tgz
+    version: v0.10.14-beta-adafa49
+  - apiVersion: v2
     appVersion: v0.10.14-beta-a8e7d4f
     created: "2024-10-15T09:20:27.087778693Z"
     description: A Helm chart for Kubernetes
@@ -281,6 +321,16 @@ entries:
     urls:
     - https://github.com/TheLunarCompany/proxy-helm-chart/releases/download/lunar-proxy-v0.10.14-beta-a8e7d4f/lunar-proxy-v0.10.14-beta-a8e7d4f.tgz
     version: v0.10.14-beta-a8e7d4f
+  - apiVersion: v2
+    appVersion: v0.10.14-beta-a1b2403
+    created: "2024-10-27T12:29:48.108847004Z"
+    description: A Helm chart for Kubernetes
+    digest: 9330a7ff6208fe8b683fe8699f9aa1f488804523cf9ff9e29c0beda895d7e6dc
+    name: lunar-proxy
+    type: application
+    urls:
+    - https://github.com/TheLunarCompany/proxy-helm-chart/releases/download/lunar-proxy-v0.10.14-beta-a1b2403/lunar-proxy-v0.10.14-beta-a1b2403.tgz
+    version: v0.10.14-beta-a1b2403
   - apiVersion: v2
     appVersion: v0.10.14-beta-9c2651c
     created: "2024-10-09T17:41:36.721389624Z"
@@ -432,6 +482,16 @@ entries:
     - https://github.com/TheLunarCompany/proxy-helm-chart/releases/download/lunar-proxy-v0.10.14-beta-3c68c60/lunar-proxy-v0.10.14-beta-3c68c60.tgz
     version: v0.10.14-beta-3c68c60
   - apiVersion: v2
+    appVersion: v0.10.14-beta-3ac4403
+    created: "2024-11-04T11:46:46.704562219Z"
+    description: A Helm chart for Kubernetes
+    digest: 482b6d3574115d14735c4200c855ad99fc0a5325edf2d87be2b80c1c13c2a084
+    name: lunar-proxy
+    type: application
+    urls:
+    - https://github.com/TheLunarCompany/proxy-helm-chart/releases/download/lunar-proxy-v0.10.14-beta-3ac4403/lunar-proxy-v0.10.14-beta-3ac4403.tgz
+    version: v0.10.14-beta-3ac4403
+  - apiVersion: v2
     appVersion: v0.10.14-beta-2f00c91
     created: "2024-10-16T12:12:32.094965534Z"
     description: A Helm chart for Kubernetes
@@ -511,6 +571,16 @@ entries:
     urls:
     - https://github.com/TheLunarCompany/proxy-helm-chart/releases/download/lunar-proxy-v0.10.14-beta-1374d49/lunar-proxy-v0.10.14-beta-1374d49.tgz
     version: v0.10.14-beta-1374d49
+  - apiVersion: v2
+    appVersion: v0.10.14-beta-0b3403c
+    created: "2024-10-28T11:56:52.503172605Z"
+    description: A Helm chart for Kubernetes
+    digest: 88b58bcc49f8dfdbc410b771f32562232da329f5cd9fbb3047d0fb3e0e4a0dba
+    name: lunar-proxy
+    type: application
+    urls:
+    - https://github.com/TheLunarCompany/proxy-helm-chart/releases/download/lunar-proxy-v0.10.14-beta-0b3403c/lunar-proxy-v0.10.14-beta-0b3403c.tgz
+    version: v0.10.14-beta-0b3403c
   - apiVersion: v2
     appVersion: v0.10.13
     created: "2024-09-29T17:30:45.435660434Z"


### PR DESCRIPTION
Based on DD Docs:
https://docs.datadoghq.com/containers/kubernetes/prometheus/?tab=kubernetesadv2#configuration

Brought it up with `helm install my-lunar-proxy ./charts/lunar-proxy --version 1.0.0-alpha-3ac4403 -f ./charts/lunar-proxy/override-values.yaml -namespace webapp` and verified I am seeing it on DD:
![image](https://github.com/user-attachments/assets/3f0e58d7-391e-41d6-a214-cac78f3e69c5)

This was included in my `override-values.yaml`:
```
lunarStreamsEnabled: true
configMapNames:
  flows: flows-config-test
  quotas: quotas-config-test
  metrics: metrics-config-test
  policies: policies-config-test
metrics:
  datadog:
    enabled: true
    namespace: "CORE-1397-testing"

serviceMonitor:
  enabled: true
serviceAccount:
  name: "lunar-proxy"

```