### PR TITLE
Support Lunar Gateway Pro

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -1,0 +1,21 @@
+name: Helm Lint CI
+
+on:
+    pull_request:
+        paths:
+            - charts/**
+
+jobs:
+  lint-lunar-proxy-chart:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Install Helm
+        run: |
+          curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+
+      - name: Run Helm Lint
+        run: helm lint ./charts/lunar-proxy

--- a/.github/workflows/release-helm-chart.yml
+++ b/.github/workflows/release-helm-chart.yml
@@ -6,6 +6,12 @@ on:
         description: "Version to deploy"
         required: true
         type: string
+      chart-version:
+        description: "Chart version to package (optional, defaults to 'version')"
+        required: false
+        type: string
+  
+  
 
 jobs:
   helm-chart:
@@ -24,12 +30,23 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@v3
+      
+      - name: Set Chart Version
+        id: set-chart-version
+        run: |
+          if [ -z "${{ inputs.chart-version }}" ]; then
+            echo "Using version input as chart-version."
+            echo "chart_version=${{ inputs.version }}" >> $GITHUB_ENV
+          else
+            echo "Using provided chart-version input."
+            echo "chart_version=${{ inputs.chart-version }}" >> $GITHUB_ENV
+          fi
 
       - name: Package
         run: |
           rm -rf .cr-release-packages
           mkdir -p .cr-release-packages
-          helm package "charts/lunar-proxy" --version v${{ inputs.version }} --app-version v${{ inputs.version }} --destination=.cr-release-packages
+          helm package "charts/lunar-proxy" --version v${{ env.chart_version }} --app-version v${{ inputs.version }} --destination=.cr-release-packages
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,0 +1,26 @@
+name: Helm Chart CI
+
+on:
+    pull_request:
+        paths:
+            - charts/**
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Install Helm
+        run: |
+          curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+
+      - name: Install Helm unittest plugin
+        run: helm plugin install https://github.com/quintush/helm-unittest
+
+      - name: Update Helm dependencies
+        run: helm dependency update ./charts/lunar-proxy
+
+      - name: Run Helm unittest
+        run: helm unittest ./charts/lunar-proxy

--- a/charts/lunar-proxy/Chart.yaml
+++ b/charts/lunar-proxy/Chart.yaml
@@ -22,3 +22,6 @@ version: 0.8.26
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "v0.8.25"
+
+# An icon can be provided for this chart, which will be displayed in the Chart Center.
+icon: https://storage.googleapis.com/lunar-webapp-assets/favicon/apple-touch-icon.png

--- a/charts/lunar-proxy/templates/_helpers.tpl
+++ b/charts/lunar-proxy/templates/_helpers.tpl
@@ -79,7 +79,7 @@ Define image repository
     {{- if .Values.pro }}
       us-central1-docker.pkg.dev/prj-common-442813/lunar-proxy-pro/lunar-proxy-pro
     {{- else }}
-      lunarapi/lunar-proxy-abc
+      lunarapi/lunar-proxy
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/lunar-proxy/templates/_helpers.tpl
+++ b/charts/lunar-proxy/templates/_helpers.tpl
@@ -68,3 +68,18 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Define image repository
+*/}}
+{{- define "image.repository" -}}
+  {{- if .Values.image.repository }}
+    {{ .Values.image.repository }}
+  {{- else }}
+    {{- if .Values.pro }}
+      us-central1-docker.pkg.dev/prj-common-442813/lunar-proxy-pro/lunar-proxy-pro
+    {{- else }}
+      lunarapi/lunar-proxy-abc
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/lunar-proxy/templates/deployment.yaml
+++ b/charts/lunar-proxy/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: '{{ include "image.repository" . | trim }}:{{ .Values.image.tag | default .Chart.AppVersion }}'
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/lunar-proxy/tests/deployment_test.yaml
+++ b/charts/lunar-proxy/tests/deployment_test.yaml
@@ -1,0 +1,33 @@
+suite: Test image configuration
+
+tests:
+  - it: should use the pro image from GCP when pro is enabled
+    template: templates/deployment.yaml
+    set:
+      pro: true
+      image:
+        tag: "v2.0.0"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "us-central1-docker.pkg.dev/prj-common-442813/lunar-proxy-pro/lunar-proxy-pro:v2.0.0"
+
+  - it: should use the public dockerhub image when pro is disabled
+    template: templates/deployment.yaml
+    set:
+      pro: false
+      image:
+        tag: "v1.0.0"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "lunarapi/lunar-proxy:v1.0.0"
+
+  - it: should use default app version if image tag is not set
+    template: templates/deployment.yaml
+    set:
+      pro: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "lunarapi/lunar-proxy:v0.8.25" # Hardcoded value from values.yaml. In reality `helm package` command in the CI pipeline would replace this with the actual appVersion

--- a/charts/lunar-proxy/values.schema.json
+++ b/charts/lunar-proxy/values.schema.json
@@ -2,6 +2,9 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
+    "pro": {
+      "type": "boolean"
+    },
     "image": {
       "type": "object",
       "properties": {
@@ -15,7 +18,6 @@
           "type": "string"
         }
       },
-      "required": ["repository"],
       "additionalProperties": false
     },
     "imagePullSecrets": {

--- a/charts/lunar-proxy/values.yaml
+++ b/charts/lunar-proxy/values.yaml
@@ -200,6 +200,7 @@ serviceMonitor:
   targetLabels: []
 
 configMapNames: {}
+secretNames: {}
 configFiles: {}
 
 policies:

--- a/charts/lunar-proxy/values.yaml
+++ b/charts/lunar-proxy/values.yaml
@@ -3,7 +3,6 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: lunarapi/lunar-proxy
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""


### PR DESCRIPTION
1. This PR adds the top level `pro` boolean field.
The repository from which to pull will change accordingly.
2. Also, it allows differing between `chartVersion` and `appVersion` in releases.
While `appVersion` is mandatory - and corresponds to a Lunar Gateway docker image version - the `chartVersion` param is optional; if not supplied, it will default to `appVersion`. The motivation for this is to allow creating Helm-chart-only fixes for the same Lunar Gateway image - which is not currently possible in a satisfactory manner since `appVersion` is taken as the image tag to pull, and both `appVersion` and `chartVersion` are being set by a single param in the Github action workflow...
3. Linter is added to CI as well as Helm `unittest`s