### PR TITLE
Polish up schema

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -18,4 +18,4 @@ jobs:
           curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
 
       - name: Run Helm Lint
-        run: helm lint ./charts/lunar-proxy
+        run: helm lint ./charts/lunar-proxy --set tenantName=foo

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "cSpell.words": ["datadoghq", "nindent", "openmetrics", "spoe"]
+  "cSpell.words": ["datadoghq", "Millis", "nindent", "openmetrics", "spoe"]
 }

--- a/charts/lunar-proxy/README.md
+++ b/charts/lunar-proxy/README.md
@@ -21,6 +21,9 @@ For example, chart version 0.10.19 will install Lunar Gateway version 0.10.19.
 When there is a need to fix only the Helm chart, a postfix will be added.
 For example, chart version 0.10.20-fix2 would still correspond to 0.10.20.
 
+## Working With Values
+This chart allows for plenty of customization options in order to cater for various needs. Please see the **Values Schema** in our [ArtifactHub](https://artifacthub.io/packages/helm/lunar/lunar-proxy) page to explore these options and learn about them. See also [Gateway Environment Variables](https://docs.lunar.dev/lunar-dev-in-production/core-settings/environment-variables/gateway-environment-variables) from our documentation in order to learn more about matching environment variables.
+
 ## Usage in ArgoCD
 Consider the following example as a recipe for using this Helm chart via ArgoCD:
 ```yaml

--- a/charts/lunar-proxy/values-old.schema.json
+++ b/charts/lunar-proxy/values-old.schema.json
@@ -1,0 +1,399 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "pro": {
+      "type": "boolean",
+      "description": "Enable the Pro (paid) version of the Lunar Proxy",
+      "default": false
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "description": "Image pull secrets",
+      "default": [],
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": ["create"],
+      "additionalProperties": true
+    },
+    "livenessProbe": {
+      "type": "object",
+      "properties": {
+        "initialDelaySeconds": {
+          "type": "integer"
+        },
+        "periodSeconds": {
+          "type": "integer"
+        }
+      }
+    },
+    "readinessProbe": {
+      "type": "object",
+      "properties": {
+        "initialDelaySeconds": {
+          "type": "integer"
+        },
+        "periodSeconds": {
+          "type": "integer"
+        }
+      }
+    },
+    "nameOverride": {
+      "type": "string",
+      "description": "deprecated"
+    },
+    "fullnameOverride": {
+      "type": "string",
+      "description": "deprecated"
+    },
+    "replicaCount": {
+      "type": "integer"
+    },
+    "podAnnotations": {
+      "type": "object"
+    },
+    "metrics": {
+      "type": "object",
+      "properties": {
+        "datadog": {
+          "type": "object",
+          "description": "Configure metric export to Datadog",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable Datadog metric export",
+              "default": false
+            },
+            "namespace": {
+              "type": "string",
+              "description": "The namespace to use for the Datadog metrics, will be used as prefix for all exported metrics",
+              "default": "lunar_proxy"
+            },
+            "includedMetrics": {
+              "type": "array",
+              "description": "An array of metric names to include in the export. Defaults to all metrics",
+              "default": [".*"],
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "podSecurityContext": {
+      "type": "object"
+    },
+    "securityContext": {
+      "type": "object"
+    },
+    "env": {
+      "type": ["string", "null"],
+      "description": "The environment Lunar Gateway runs in",
+      "default": null
+    },
+    "telemetryEnabled": {
+      "type": "boolean",
+      "description": "Enable telemetry reporting",
+      "default": true
+    },
+    "telemetryLogLevel": {
+      "type": "string",
+      "description": "The log level for telemetry reporting",
+      "default": "info"
+    },
+    "logLevel": {
+      "type": "string",
+      "description": "The log level for the Lunar Gateway",
+      "default": "warn"
+    },
+    "tenantName": {
+      "type": "string",
+      "description": "The name of the tenant, usually the organization name, perhaps with the environment as suffix"
+    },
+    "awsAccessKeyId": {
+      "type": ["string", "null"],
+      "description": "AWS access key ID"
+    },
+    "awsSecretAccessKey": {
+      "type": ["string", "null"],
+      "description": "AWS secret access key"
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "healthCheckPort": {
+          "type": "integer"
+        },
+        "adminPort": {
+          "type": "integer"
+        },
+        "annotations": {
+          "type": "object"
+        }
+      },
+      "required": ["type", "port"],
+      "additionalProperties": false
+    },
+    "resources": {
+      "type": "object",
+      "description": "Resource requests and limits"
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "className": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "host": {
+                "type": "string"
+              },
+              "paths": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                },
+                "properties": {
+                  "path": {
+                    "type": "string"
+                  },
+                  "pathType": {
+                    "type": "string"
+                  }
+                },
+                "required": ["path", "pathType"]
+              }
+            }
+          }
+        },
+        "tls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "secretName": {
+                "type": "string"
+              },
+              "hosts": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "serviceMonitor": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "namespace": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "additionalLabels": {
+          "type": "object"
+        },
+        "interval": {
+          "type": "string"
+        },
+        "scheme": {
+          "type": "string"
+        },
+        "bearerTokenFile": {
+          "type": "string"
+        },
+        "tlsConfig": {
+          "type": "object"
+        },
+        "scrapeTimeout": {
+          "type": "string"
+        },
+        "metricRelabelings": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "relabelings": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "targetLabels": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      },
+      "required": ["enabled"]
+    },
+    "configMapNames": {
+      "type": "object",
+      "properties": {
+        "flows": {
+          "type": "string"
+        },
+        "quotas": {
+          "type": "string"
+        },
+        "pathParams": {
+          "type": "string"
+        },
+        "root": {
+          "type": "string"
+        },
+        "policies": {
+          "type": "string"
+        }
+      }
+    },
+    "secretNames": {
+      "type": "object",
+      "properties": {
+        "tlsCerts": {
+          "type": "string"
+        },
+        "mtlsCerts": {
+          "type": "string"
+        }
+      }
+    },
+    "policies": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "timeouts": {
+      "type": "object",
+      "properties": {
+        "spoe": {
+          "type": "object",
+          "properties": {
+            "processingTimeoutSec": {
+              "type": "integer"
+            },
+            "helloTimeoutMillis": {
+              "type": "integer"
+            }
+          }
+        },
+        "proxy": {
+          "type": "object",
+          "properties": {
+            "connectTimeoutSec": {
+              "type": "integer"
+            },
+            "clientTimeoutSec": {
+              "type": "integer"
+            },
+            "serverTimeoutSec": {
+              "type": "integer"
+            }
+          }
+        },
+        "retryRequestTimeoutSec": {
+          "type": "integer"
+        }
+      }
+    },
+    "redis": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string"
+        },
+        "useCluster": {
+          "type": "boolean"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "useCaCert": {
+          "type": "boolean"
+        },
+        "caCertPath": {
+          "type": "string"
+        },
+        "useClientCert": {
+          "type": "boolean"
+        },
+        "clientCertPath": {
+          "type": "string"
+        },
+        "clientKeyPath": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "gateway": {
+    "type": "object",
+    "properties": {
+      "maxConn": {
+        "type": "integer"
+      },
+      "bufferSize": {
+        "type": "integer"
+      },
+      "accessLogOutput": {
+        "type": "string"
+      },
+      "doctorReportIntervalMinutes": {
+        "type": "integer"
+      }
+    }
+  },
+  "tlsPassthrough": {
+    "type": "boolean"
+  },
+  "additionalProperties": true,
+  "required": ["tenantName"]
+}

--- a/charts/lunar-proxy/values.schema.json
+++ b/charts/lunar-proxy/values.schema.json
@@ -3,25 +3,19 @@
   "type": "object",
   "properties": {
     "pro": {
-      "type": "boolean"
+      "type": "boolean",
+      "description": "Enable the Pro (paid) version of the Lunar Proxy",
+      "default": false
     },
-    "image": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string"
-        },
-        "pullPolicy": {
-          "type": "string"
-        },
-        "tag": {
-          "type": "string"
-        }
-      },
-      "additionalProperties": false
+    "lunarStreamsEnabled": {
+      "type": "boolean",
+      "description": "Enable Lunar Flows. Sets the `LUNAR_STREAMS_ENABLED` environment variable",
+      "default": true
     },
     "imagePullSecrets": {
       "type": "array",
+      "description": "Image pull secrets",
+      "default": [],
       "items": {
         "type": "object",
         "properties": {
@@ -32,195 +26,80 @@
       }
     },
     "serviceAccount": {
+      "description": "Kubernetes compatible",
       "type": "object",
       "properties": {
         "create": {
-          "type": "boolean"
+          "type": "boolean",
+          "default": true
         },
         "annotations": {
           "type": "object"
         },
         "name": {
-          "type": "string"
-        }
+          "type": "string",
+          "default": "lunar-proxy"
+        },
+        "additionalProperties": true
       },
-      "required": ["create"],
-      "additionalProperties": true
-    },
-    "livenessProbe": {
-      "type": "object",
-      "properties": {
-        "initialDelaySeconds": {
-          "type": "integer"
-        },
-        "periodSeconds": {
-          "type": "integer"
-        }
-      }
-    },
-    "readinessProbe": {
-      "type": "object",
-      "properties": {
-        "initialDelaySeconds": {
-          "type": "integer"
-        },
-        "periodSeconds": {
-          "type": "integer"
-        }
-      }
-    },
-    "nameOverride": {
-      "type": "string"
-    },
-    "fullnameOverride": {
-      "type": "string"
-    },
-    "replicaCount": {
-      "type": "integer"
-    },
-    "podAnnotations": {
-      "type": "object"
-    },
-    "metrics": {
-      "type": "object",
-      "properties": {
-        "datadog": {
-          "type": "object",
-          "properties": {
-            "enabled": {
-              "type": "boolean"
-            },
-            "namespace": {
-              "type": "string"
-            },
-            "includedMetrics": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
+      "livenessProbe": {
+        "type": "object",
+        "description": "Kubernetes compatible",
+        "properties": {
+          "initialDelaySeconds": {
+            "type": "integer",
+            "default": 15
+          },
+          "periodSeconds": {
+            "type": "integer",
+            "default": 5
           }
         }
-      }
-    },
-    "podSecurityContext": {
-      "type": "object"
-    },
-    "securityContext": {
-      "type": "object"
-    },
-    "env": {
-      "type": ["string", "null"]
-    },
-    "telemetryEnabled": {
-      "type": "boolean"
-    },
-    "telemetryLogLevel": {
-      "type": "string"
-    },
-    "logLevel": {
-      "type": "string"
-    },
-    "tenantName": {
-      "type": ["string", "null"]
-    },
-    "awsAccessKeyId": {
-      "type": ["string", "null"]
-    },
-    "awsSecretAccessKey": {
-      "type": ["string", "null"]
-    },
-    "lunarManaged": {
-      "type": "boolean"
-    },
-    "lunarFlushSeconds": {
-      "type": "integer"
-    },
-    "service": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string"
-        },
-        "port": {
-          "type": "integer"
-        },
-        "healthCheckPort": {
-          "type": "integer"
-        },
-        "adminPort": {
-          "type": "integer"
-        },
-        "annotations": {
-          "type": "object"
+      },
+      "readinessProbe": {
+        "type": "object",
+        "description": "Kubernetes compatible",
+        "properties": {
+          "initialDelaySeconds": {
+            "type": "integer",
+            "default": 5
+          },
+          "periodSeconds": {
+            "type": "integer",
+            "default": 2
+          }
         }
       },
-      "required": ["type", "port"],
-      "additionalProperties": false
-    },
-    "resources": {
-      "type": "object"
-    },
-    "nodeSelector": {
-      "type": "object"
-    },
-    "tolerations": {
-      "type": "array",
-      "items": {
+      "replicaCount": {
+        "type": "integer",
+        "description": "Kubernetes compatible",
+        "default": 1
+      },
+      "podAnnotations": {
+        "description": "Kubernetes compatible",
         "type": "object"
-      }
-    },
-    "affinity": {
-      "type": "object"
-    },
-    "ingress": {
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "type": "boolean"
-        },
-        "className": {
-          "type": "string"
-        },
-        "annotations": {
-          "type": "object"
-        },
-        "hosts": {
-          "type": "array",
-          "items": {
+      },
+      "metrics": {
+        "type": "object",
+        "properties": {
+          "datadog": {
             "type": "object",
+            "description": "Configure metric export to Datadog",
             "properties": {
-              "host": {
-                "type": "string"
+              "enabled": {
+                "type": "boolean",
+                "description": "Enable Datadog metric export",
+                "default": false
               },
-              "paths": {
-                "type": "array",
-                "items": {
-                  "type": "object"
-                },
-                "properties": {
-                  "path": {
-                    "type": "string"
-                  },
-                  "pathType": {
-                    "type": "string"
-                  }
-                },
-                "required": ["path", "pathType"]
-              }
-            }
-          }
-        },
-        "tls": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "secretName": {
-                "type": "string"
+              "namespace": {
+                "type": "string",
+                "description": "The namespace to use for the Datadog metrics, will be used as prefix for all exported metrics",
+                "default": "lunar_proxy"
               },
-              "hosts": {
+              "includedMetrics": {
                 "type": "array",
+                "description": "An array of metric names to include in the export. Defaults to all metrics",
+                "default": [".*"],
                 "items": {
                   "type": "string"
                 }
@@ -228,179 +107,225 @@
             }
           }
         }
-      }
-    },
-    "serviceMonitor": {
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "type": "boolean"
-        },
-        "port": {
-          "type": "integer"
-        },
-        "namespace": {
-          "type": "string"
-        },
-        "annotations": {
-          "type": "object"
-        },
-        "additionalLabels": {
-          "type": "object"
-        },
-        "interval": {
-          "type": "string"
-        },
-        "scheme": {
-          "type": "string"
-        },
-        "bearerTokenFile": {
-          "type": "string"
-        },
-        "tlsConfig": {
-          "type": "object"
-        },
-        "scrapeTimeout": {
-          "type": "string"
-        },
-        "metricRelabelings": {
-          "type": "array",
-          "items": {
-            "type": "object"
+      },
+      "env": {
+        "type": "string",
+        "description": "The environment Lunar Gateway runs in. Sets the `ENV` environment variable",
+        "default": null
+      },
+      "telemetryEnabled": {
+        "type": "boolean",
+        "description": "Enable telemetry reporting. Sets the `LUNAR_TELEMETRY` environment variable",
+        "default": true
+      },
+      "telemetryLogLevel": {
+        "type": "string",
+        "description": "The log level for telemetry reporting. Sets the `LUNAR_TELEMETRY_LOG_LEVEL` environment variable",
+        "default": "info"
+      },
+      "logLevel": {
+        "type": "string",
+        "description": "The log level for the Lunar Gateway. Sets the `LOG_LEVEL` environment variable",
+        "default": "warn"
+      },
+      "tenantName": {
+        "type": "string",
+        "description": "The name of the tenant, usually the organization name, perhaps with the environment as suffix. Sets the `TENANT_NAME` environment variable"
+      },
+      "awsAccessKeyId": {
+        "type": "string",
+        "description": "AWS access key ID. Sets the `AWS_ACCESS_KEY_ID` environment variable"
+      },
+      "awsSecretAccessKey": {
+        "type": "string",
+        "description": "AWS secret access key. Sets the `AWS_SECRET_ACCESS_KEY` environment variable"
+      },
+      "service": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Sets the service type for the Kubernetes service"
+          },
+          "port": {
+            "type": "integer",
+            "description": "Sets Lunar Gateway main port for traffic"
+          },
+          "healthCheckPort": {
+            "type": "integer",
+            "default": 8040,
+            "description": "Sets Lunar Gateway healthcheck port"
+          },
+          "adminPort": {
+            "type": "integer",
+            "default": 8081,
+            "description": "Sets Lunar Gateway admin port"
+          },
+          "annotations": {
+            "type": "object",
+            "description": "Allows for setting annotations on the Kubernetes service"
           }
         },
-        "relabelings": {
-          "type": "array",
-          "items": {
-            "type": "object"
-          }
-        },
-        "targetLabels": {
-          "type": "array",
-          "items": {
-            "type": "object"
+        "required": ["type", "port"],
+        "additionalProperties": false
+      },
+      "resources": {
+        "type": "object",
+        "description": "Kubernetes requests and limits"
+      },
+      "configMapNames": {
+        "type": "object",
+        "description": "ConfigMap names correlating to configuration to be used by Lunar Proxy. See https://docs.lunar.dev/flows-configurations/#folder-structure for folder structure used by Lunar Gateway. Alternatively, the `.configFiles` field can be used to provide the configurations inline",
+        "properties": {
+          "flows": {
+            "type": "string",
+            "description": "ConfigMap name containing Lunar Proxy Flows. Mounts to `/etc/lunar-proxy/flows`"
+          },
+          "quotas": {
+            "type": "string",
+            "description": "ConfigMap name containing Lunar Proxy Quotas, Mounts to `/etc/lunar-proxy/quotas`"
+          },
+          "pathParams": {
+            "type": "string",
+            "description": "ConfigMap name containing Lunar Proxy Path Params. Mounts to `/etc/lunar-proxy/path_params`"
+          },
+          "root": {
+            "type": "string",
+            "description": "ConfigMap name containing Lunar Proxy root config folder - through which `gateway_config.yaml` and `metrics.yaml` can be supplied. Mounts to `/etc/lunar-proxy` without overriding other configurations in subfolders"
+          },
+          "policies": {
+            "type": "string",
+            "description": "ConfigMap name containing Lunar Proxy policies.yaml file. Only relevant if `lunarStreamsEnabled` is set to `false`"
           }
         }
       },
-      "required": ["enabled"]
-    },
-    "configMapNames": {
-      "type": "object",
-      "properties": {
-        "flows": {
-          "type": "string"
-        },
-        "quotas": {
-          "type": "string"
-        },
-        "pathParams": {
-          "type": "string"
-        },
-        "root": {
-          "type": "string"
-        },
-        "policies": {
-          "type": "string"
+      "secretNames": {
+        "type": "object",
+        "description": "Secret names correlating to secrets to be used by Lunar Proxy",
+        "properties": {
+          "tlsCerts": {
+            "type": "string",
+            "description": "Secret name containing TLS certificates for Lunar Proxy. Mounts to `/etc/lunar-proxy/certs/tls`"
+          },
+          "mtlsCerts": {
+            "type": "string",
+            "description": "Secret name containing mTLS certificates for Lunar Proxy. Mounts to `/etc/lunar-proxy/certs/mtls`"
+          }
         }
-      }
-    },
-    "secretNames": {
-      "type": "object",
-      "properties": {
-        "tlsCerts": {
-          "type": "string"
-        },
-        "mtlsCerts": {
-          "type": "string"
-        }
-      }
-    },
-    "policies": {
-      "type": "object",
-      "additionalProperties": true
-    },
-    "timeouts": {
-      "type": "object",
-      "properties": {
-        "spoe": {
-          "type": "object",
-          "properties": {
-            "processingTimeoutSec": {
-              "type": "integer"
-            },
-            "helloTimeoutMillis": {
-              "type": "integer"
+      },
+      "policies": {
+        "type": "object",
+        "description": "Inline content for policies.yaml. Only relevant if `lunarStreamsEnabled` is set to `false`",
+        "additionalProperties": true
+      },
+      "timeouts": {
+        "type": "object",
+        "description": "Timeouts for various components in Lunar Proxy",
+        "properties": {
+          "spoe": {
+            "type": "object",
+            "properties": {
+              "processingTimeoutSec": {
+                "type": "integer",
+                "description": "Sets the `LUNAR_SPOE_PROCESSING_TIMEOUT_SEC` environment variable"
+              },
+              "helloTimeoutMillis": {
+                "type": "integer",
+                "description": "Sets the `LUNAR_SPOE_HELLO_TIMEOUT_MS` environment variable"
+              }
             }
-          }
-        },
-        "proxy": {
-          "type": "object",
-          "properties": {
-            "connectTimeoutSec": {
-              "type": "integer"
-            },
-            "clientTimeoutSec": {
-              "type": "integer"
-            },
-            "serverTimeoutSec": {
-              "type": "integer"
+          },
+          "proxy": {
+            "type": "object",
+            "properties": {
+              "connectTimeoutSec": {
+                "type": "integer",
+                "description": "Sets the `LUNAR_CONNECT_TIMEOUT_SEC` environment variable"
+              },
+              "clientTimeoutSec": {
+                "type": "integer",
+                "description": "Sets the `LUNAR_CLIENT_TIMEOUT_SEC` environment variable"
+              },
+              "serverTimeoutSec": {
+                "type": "integer",
+                "description": "Sets the `LUNAR_SERVER_TIMEOUT_SEC` environment variable"
+              }
             }
+          },
+          "retryRequestTimeoutSec": {
+            "type": "integer",
+            "description": "Sets the `LUNAR_RETRY_REQUEST_TIMEOUT_SEC` environment variable"
           }
-        },
-        "retryRequestTimeoutSec": {
-          "type": "integer"
+        }
+      },
+      "redis": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "The URL to the Redis instance. Needs to include schema and port. For TLS support, use `rediss://` as schema. This field is mandatory if `pro` is set to `true`",
+            "default": null,
+            "examples": ["redis://your-instance:6379"]
+          },
+          "useCluster": {
+            "type": "boolean",
+            "description": "Whether to connect to Redis as a cluster. Sets the `REDIS_USE_CLUSTER` environment variable"
+          },
+          "prefix": {
+            "type": "string",
+            "description": "A prefix to use for keys in Redis. Sets the `REDIS_PREFIX` environment variable"
+          },
+          "useCaCert": {
+            "type": "boolean",
+            "description": "Whether to use a CA certificate for Redis. Sets the `REDIS_USE_CA_CERT` environment variable"
+          },
+          "caCertPath": {
+            "type": "string",
+            "description": "The path to the CA certificate for Redis. Sets the `REDIS_CA_CERT_PATH` environment variable"
+          },
+          "useClientCert": {
+            "type": "boolean",
+            "description": "Whether to use a client certificate for Redis. Sets the `REDIS_USE_CLIENT_CERT` environment variable"
+          },
+          "clientCertPath": {
+            "type": "string",
+            "description": "The path to the client certificate for Redis. Sets the `REDIS_CLIENT_CERT_PATH` environment variable"
+          },
+          "clientKeyPath": {
+            "type": "string",
+            "description": "The path to the client key for Redis. Sets the `REDIS_CLIENT_KEY_PATH` environment variable"
+          }
         }
       }
     },
-    "redis": {
+    "gateway": {
       "type": "object",
       "properties": {
-        "url": {
-          "type": "string"
+        "maxConn": {
+          "type": "integer",
+          "description": "The maximum number of connections Lunar Gateway can handle. Sets the `LUNAR_MAXCONN` environment variable"
         },
-        "useCluster": {
-          "type": "boolean"
+        "bufferSize": {
+          "type": "integer",
+          "description": "The buffer size for Lunar Proxy. Sets the `GATEWAY_BUFFER_SIZE` environment variable"
         },
-        "prefix": {
-          "type": "string"
+        "accessLogOutput": {
+          "type": "string",
+          "description": "Sets output for the Lunar Gateway's access log. Sets the `LUNAR_ACCESS_LOGS_OUTPUT` environment variable",
+          "enum": ["stdout"],
+          "default": null
         },
-        "useCaCert": {
-          "type": "boolean"
-        },
-        "caCertPath": {
-          "type": "string"
-        },
-        "useClientCert": {
-          "type": "boolean"
-        },
-        "clientCertPath": {
-          "type": "string"
-        },
-        "clientKeyPath": {
-          "type": "string"
+        "doctorReportIntervalMinutes": {
+          "type": "integer",
+          "description": "The interval in minutes for the doctor report. Sets the `DOCTOR_REPORT_INTERVAL_MINUTES` environment variable"
         }
       }
-    }
+    },
+    "tlsPassthrough": {
+      "type": "boolean",
+      "description": "Enable TLS passthrough for Lunar Proxy. Sets the `TLS_PASSTHROUGH_ON` environment variable"
+    },
+    "additionalProperties": true
   },
-  "gateway": {
-    "type": "object",
-    "properties": {
-      "maxConn": {
-        "type": "integer"
-      },
-      "bufferSize": {
-        "type": "integer"
-      },
-      "accessLogOutput": {
-        "type": "string"
-      },
-      "doctorReportIntervalMinutes": {
-        "type": "integer"
-      }
-    }
-  },
-  "tlsPassthrough": {
-    "type": "boolean"
-  },
-  "additionalProperties": true
+  "required": ["tenantName"]
 }

--- a/charts/lunar-proxy/values.yaml
+++ b/charts/lunar-proxy/values.yaml
@@ -27,7 +27,7 @@ lunarAPIKey: null # Set the API key directly
 lunarAPIKeySecretName: null # Set the API key from a secret (key must be named lunarAPIKey)
 
 env: null
-logLevel: "error"
+logLevel: "warn"
 tenantName: null
 lunarStreamsEnabled: true
 
@@ -41,9 +41,8 @@ lunarManaged: false
 # Redis configuration
 redis:
   prefix: "lunar"
-# redisUrl: null
-# redisUseCluster: false
-# redisPrefix: "lunar"
+  url: null
+  useCluster: false
 
 timeouts:
   spoe: {}


### PR DESCRIPTION
This PR adds descriptions to our `values.schema.json` file so ArtifactHub can display it nicely.
It also reduced properties which @RotemY-Lunar and I found unnecessary (for now). Kept the old files in `values-old.schema.json`.
It also sets the default log level to `warn`.