### PR TITLE
MCPX chart sketch

### DIFF
--- a/.github/workflows/release-helm-chart.yml
+++ b/.github/workflows/release-helm-chart.yml
@@ -2,6 +2,13 @@ name: Helm Chart Release
 on:
   workflow_dispatch:
     inputs:
+      chart-name:
+        description: "Chart name to release (e.g., lunar-proxy or lunar-mcpx)"
+        required: true
+        type: choice
+        options:
+          - lunar-proxy
+          - lunar-mcpx
       version: # Effectively, the version of Lunar Gateway's Docker image tag
         description: "Version to deploy"
         required: true
@@ -10,8 +17,6 @@ on:
         description: "Chart version to package (optional, defaults to 'version')"
         required: false
         type: string
-  
-  
 
 jobs:
   helm-chart:
@@ -30,7 +35,7 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@v3
-      
+
       - name: Filter out pre-release versions
         run: |
           if [[ "${{ inputs.version }}" == *-* ]]; then
@@ -44,7 +49,6 @@ jobs:
           else
             echo "Stable version detected: ${{ inputs.version }}."
           fi
-
 
       - name: Set Chart Version
         id: set-chart-version
@@ -62,24 +66,24 @@ jobs:
         run: |
           # Ensure the environment variable is exported so that envsubst can pick it up
           export CHART_VERSION="${{ env.chart_version }}"
-          envsubst < charts/lunar-proxy/README.tpl.md > charts/lunar-proxy/README.md
+          envsubst < charts/${{ inputs.chart-name }}/README.tpl.md > charts/${{ inputs.chart-name }}/README.md
 
       # Commit the updated README.md if there are any changes
       - name: Commit updated README
         run: |
-          git add charts/lunar-proxy/README.md
+          git add charts/${{ inputs.chart-name }}/README.md
           if ! git diff --cached --quiet; then
-            git commit -m "Update README with chart version v${{ env.chart_version }}"
+            git commit -m "Update ${{ inputs.chart-name }} README with chart version v${{ env.chart_version }}"
             git push
           else
-            echo "No changes in charts/lunar-proxy/README.md to commit."
+            echo "No changes in charts/${{ inputs.chart-name }}/README.md to commit."
           fi
 
       - name: Package
         run: |
           rm -rf .cr-release-packages
           mkdir -p .cr-release-packages
-          helm package "charts/lunar-proxy" --version v${{ env.chart_version }} --app-version v${{ inputs.version }} --destination=.cr-release-packages
+          helm package "charts/${{ inputs.chart-name }}" --version v${{ env.chart_version }} --app-version v${{ inputs.version }} --destination=.cr-release-packages
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .history/
+
+# gateway
 /charts/lunar-proxy/override-values.yaml
 /charts/lunar-proxy/flows
 /charts/lunar-proxy/quotas
@@ -6,3 +8,6 @@
 /charts/lunar-proxy/certs
 /charts/lunar-proxy/path_params
 /charts/lunar-proxy/policies.yaml
+
+# mcpx
+/charts/lunar-mcpx/override-values.yaml

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,10 @@
 {
-  "cSpell.words": ["datadoghq", "Millis", "nindent", "openmetrics", "spoe"]
+  "cSpell.words": [
+    "datadoghq",
+    "mcpx",
+    "Millis",
+    "nindent",
+    "openmetrics",
+    "spoe"
+  ]
 }

--- a/charts/lunar-mcpx/Chart.yaml
+++ b/charts/lunar-mcpx/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: lunar-mcpx
+description: Helm chart for Lunar MCPX
+
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+icon: https://storage.googleapis.com/lunar-webapp-assets/favicon/apple-touch-icon.png

--- a/charts/lunar-mcpx/README.md
+++ b/charts/lunar-mcpx/README.md
@@ -1,0 +1,74 @@
+# Lunar MCPX Helm Chart
+
+## Installation
+This Helm chart will install Lunar MCPX on your Kubernetes cluster.
+
+```bash
+helm install my-mcpx lunar/lunar-mcpx --version 0.1.0
+```
+
+## Versioning
+This Helm chart follows [SemVer](https://semver.org/) principles. It's version correlates directly with MCPX's container image versions.
+
+## Working With Values
+Lunar's MCPX accepts configuration input via environment variables and configuration files. See [here](https://github.com/TheLunarCompany/lunar/tree/main/mcpx#configuration) for further information.
+As with any other Helm chart, you may create a separate values file to override chart's defaults. Consider a file named `override-values.yaml` looking like this:
+```yaml
+config:
+  appYaml: |
+    auth:
+      enabled: false
+    permissions:
+      base: "block"
+```
+
+We can install the chart with
+```bash
+helm install my-mcpx lunar/lunar-mcpx --version 0.1.0 -f ./charts/lunar-mcpx/override-values.yaml
+```
+
+## Supplying Secrets
+You may pass the optional value `secretRef` in order to refer to an existing K8s secret:
+```yaml
+secretRef:
+  name: my-mcpx-secret
+  keys:
+    - API_KEY                 # Used when `auth.enabled` is set to true
+    - SOME_3RD_PARTY_API_KEY  # Any secret required by a target MCP server as env var
+```
+MCPX will inject this environment variables from the referenced secret automatically.
+
+
+## Usage in ArgoCD
+Consider the following example as a recipe for using this Helm chart via ArgoCD:
+```yaml
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: lunar-mcpx
+  namespace: cd
+spec:
+  destination:
+    namespace: lunar-mcpx
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    repoURL: https://thelunarcompany.github.io/proxy-helm-chart/
+    targetRevision: '0.1.0'
+    chart: lunar-mcpx
+    helm:
+      values: |
+        config:
+          appYaml: |
+            auth:
+              enabled: false
+            permissions:
+              base: "block"
+  syncPolicy:
+    automated: {}
+    syncOptions:
+    - CreateNamespace=true
+```
+
+Here, the `spec.source.helm.values` field effectively serves as a value overriding mechanism - similar to the ones we've used above.

--- a/charts/lunar-mcpx/README.tpl.md
+++ b/charts/lunar-mcpx/README.tpl.md
@@ -1,0 +1,74 @@
+# Lunar MCPX Helm Chart
+
+## Installation
+This Helm chart will install Lunar MCPX on your Kubernetes cluster.
+
+```bash
+helm install my-mcpx lunar/lunar-mcpx --version $CHART_VERSION
+```
+
+## Versioning
+This Helm chart follows [SemVer](https://semver.org/) principles. It's version correlates directly with MCPX's container image versions.
+
+## Working With Values
+Lunar's MCPX accepts configuration input via environment variables and configuration files. See [here](https://github.com/TheLunarCompany/lunar/tree/main/mcpx#configuration) for further information.
+As with any other Helm chart, you may create a separate values file to override chart's defaults. Consider a file named `override-values.yaml` looking like this:
+```yaml
+config:
+  appYaml: |
+    auth:
+      enabled: false
+    permissions:
+      base: "block"
+```
+
+We can install the chart with
+```bash
+helm install my-mcpx lunar/lunar-mcpx --version $CHART_VERSION -f ./charts/lunar-mcpx/override-values.yaml
+```
+
+## Supplying Secrets
+You may pass the optional value `secretRef` in order to refer to an existing K8s secret:
+```yaml
+secretRef:
+  name: my-mcpx-secret
+  keys:
+    - API_KEY                 # Used when `auth.enabled` is set to true
+    - SOME_3RD_PARTY_API_KEY  # Any secret required by a target MCP server as env var
+```
+MCPX will inject this environment variables from the referenced secret automatically.
+
+
+## Usage in ArgoCD
+Consider the following example as a recipe for using this Helm chart via ArgoCD:
+```yaml
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: lunar-mcpx
+  namespace: cd
+spec:
+  destination:
+    namespace: lunar-mcpx
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    repoURL: https://thelunarcompany.github.io/proxy-helm-chart/
+    targetRevision: '$CHART_VERSION'
+    chart: lunar-mcpx
+    helm:
+      values: |
+        config:
+          appYaml: |
+            auth:
+              enabled: false
+            permissions:
+              base: "block"
+  syncPolicy:
+    automated: {}
+    syncOptions:
+    - CreateNamespace=true
+```
+
+Here, the `spec.source.helm.values` field effectively serves as a value overriding mechanism - similar to the ones we've used above.

--- a/charts/lunar-mcpx/templates/_helpers.tpl
+++ b/charts/lunar-mcpx/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "lunar-mcpx.fullname" -}}
+{{ .Release.Name }}
+{{- end }}

--- a/charts/lunar-mcpx/templates/configmap.yaml
+++ b/charts/lunar-mcpx/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "lunar-mcpx.fullname" . }}-config
+data:
+  mcp.json: |
+{{ .Values.config.mcpJson | indent 4 }}
+  app.yaml: |
+{{ .Values.config.appYaml | indent 4 }}

--- a/charts/lunar-mcpx/templates/deployment.yaml
+++ b/charts/lunar-mcpx/templates/deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lunar-mcpx.fullname" . }}
+  labels:
+    app: {{ include "lunar-mcpx.fullname" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "lunar-mcpx.fullname" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "lunar-mcpx.fullname" . }}
+    spec:
+      containers:
+        - name: mcpx
+          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 9000
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: mcp-config-vol
+              mountPath: /config
+              readOnly: true
+          env:
+          {{- if .Values.secretRef }}
+            {{- range .Values.secretRef.keys }}
+            - name: {{ . }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.secretRef.name }}
+                  key: {{ . }}
+            {{- end }}
+          {{- end }}
+      volumes:
+        - name: mcp-config-vol
+          configMap:
+            name: {{ include "lunar-mcpx.fullname" . }}-config

--- a/charts/lunar-mcpx/templates/service.yaml
+++ b/charts/lunar-mcpx/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lunar-mcpx.fullname" . }}
+  labels:
+    app: {{ include "lunar-mcpx.fullname" . }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app: {{ include "lunar-mcpx.fullname" . }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: 9000

--- a/charts/lunar-mcpx/values.schema.json
+++ b/charts/lunar-mcpx/values.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "replicaCount": {
+      "type": "integer",
+      "description": "Number of replicas to run",
+      "default": 1
+    },
+    "config": {
+      "type": "object",
+      "description": "Inline application configuration files",
+      "properties": {
+        "mcpJson": {
+          "type": "string",
+          "description": "Content of mcp.json"
+        },
+        "appYaml": {
+          "type": "string",
+          "description": "content of app.yaml"
+        }
+      }
+    },
+    "secretRef": {
+      "type": "object",
+      "description": "Reference to a Kubernetes Secret that provides credentials and tokens",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the Kubernetes Secret"
+        },
+        "keys": {
+          "type": "array",
+          "description": "List of secret keys to mount as environment variables",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": ["name"]
+    }
+  },
+  "required": ["replicaCount"]
+}

--- a/charts/lunar-mcpx/values.yaml
+++ b/charts/lunar-mcpx/values.yaml
@@ -1,0 +1,35 @@
+replicaCount: 1
+
+image:
+  repository: us-central1-docker.pkg.dev/prj-common-442813/mcpx/mcpx
+  tag: ""
+  pullPolicy: IfNotPresent
+
+service:
+  type: LoadBalancer
+  port: 9000
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 264Mi
+  requests:
+    cpu: 250m
+    memory: 128Mi
+
+config:
+  mcpJson: |
+    {
+      "mcpServers": {
+        "time": {
+          "command": "uvx",
+          "args": ["mcp-server-time", "--local-timezone=America/New_York"]
+        }
+      }
+    }
+
+  appYaml: |
+    auth:
+      enabled: false
+    permissions:
+      base: "allow"

--- a/charts/lunar-mcpx/values.yaml
+++ b/charts/lunar-mcpx/values.yaml
@@ -33,3 +33,9 @@ config:
       enabled: false
     permissions:
       base: "allow"
+
+secretRef:
+  name: my-mcpx-secret
+  keys:
+    - API_KEY                 # Used when `auth.enabled` is set to true
+    - SOME_3RD_PARTY_API_KEY  # Any secret required by a target MCP server as env var


### PR DESCRIPTION
This PR adds a new Helm chart - MCPX.
It breaks the CI for releasing a Helm chart by forcing input of `chart-name`. See [this lunar-private PR](https://github.com/TheLunarCompany/lunar-private/pull/1749) to accompany this.