### PR TITLE
[mcpx] Update readme and values

### DIFF
--- a/charts/lunar-mcpx/README.tpl.md
+++ b/charts/lunar-mcpx/README.tpl.md
@@ -8,11 +8,14 @@ helm install my-mcpx lunar/lunar-mcpx --version $CHART_VERSION
 ```
 
 ## Versioning
-This Helm chart follows [SemVer](https://semver.org/) principles. It's version correlates directly with MCPX's container image versions.
+This Helm chart follows [SemVer](https://semver.org/) principles. Its version correlates directly with MCPX's container image versions.
 
-## Working With Values
-Lunar's MCPX accepts configuration input via environment variables and configuration files. See [here](https://github.com/TheLunarCompany/lunar/tree/main/mcpx#configuration) for further information.
-As with any other Helm chart, you may create a separate values file to override chart's defaults. Consider a file named `override-values.yaml` looking like this:
+## Configuration & Working With Values
+Lunar's MCPX Helm Chart accepts configuration input via Helm's values. Inspect `values.yaml` and `values.schema.json` for full description of what is available.
+
+Supplying filesystem-driven configuration is done via the `config` value. it maps the nested `mcpJson` and `appYaml` keys into the respective configuration files, and the chart ensures that they will be available to MCPX on runtime. See more info about these files in the official docs ([1](https://docs.lunar.dev/mcpx/target_mcp_servers), [2](https://docs.lunar.dev/mcpx/access_control_list), [3](https://docs.lunar.dev/mcpx/api_key_auth)).
+
+As with any other Helm chart, you may create a separate values file to easily override chart's defaults. Consider a file named `override-values.yaml` looking like this:
 ```yaml
 config:
   appYaml: |
@@ -22,7 +25,7 @@ config:
       base: "block"
 ```
 
-We can install the chart with
+We can then install the chart with
 ```bash
 helm install my-mcpx lunar/lunar-mcpx --version $CHART_VERSION -f ./charts/lunar-mcpx/override-values.yaml
 ```
@@ -36,8 +39,10 @@ secretRef:
     - API_KEY                 # Used when `auth.enabled` is set to true
     - SOME_3RD_PARTY_API_KEY  # Any secret required by a target MCP server as env var
 ```
-MCPX will inject this environment variables from the referenced secret automatically.
+MCPX will inject these environment variables from the referenced secret automatically and they will be available in its runtime.
 
+## Healthcheck
+Lunar MCPX responds to `GET /healthcheck` endpoint. This chart configures a Kubernetes `livenessProbe` and `readinessProbe` to use this endpoint, ensuring that the MCPX pod is healthy and ready to serve requests. Note that the healthcheck endpoint is not protected by authentication, so it can be accessed without any credentials. Also, it is not logged as part of the MCPX access logs to avoid spamming the logs.
 
 ## Usage in ArgoCD
 Consider the following example as a recipe for using this Helm chart via ArgoCD:

--- a/charts/lunar-mcpx/values.yaml
+++ b/charts/lunar-mcpx/values.yaml
@@ -20,6 +20,7 @@ resources:
 healthcheck:
   path: /healthcheck
 
+  # healthcheck.readinessProbe is used to configure the readiness probe for the mcpx deployment.
   readinessProbe:
     enabled: true
     initialDelaySeconds: 5
@@ -28,6 +29,7 @@ healthcheck:
     failureThreshold: 3
     successThreshold: 1
 
+  # healthcheck.livenessProbe is used to configure the liveness probe for the mcpx deployment.
   livenessProbe:
     enabled: true
     initialDelaySeconds: 10
@@ -35,23 +37,21 @@ healthcheck:
     timeoutSeconds: 1
     failureThreshold: 3
 
+# logLevel is the log level for the mcpx deployment.
 logLevel: info
 
 metrics:
+  # metrics.enabled is used to enable or disable the metrics server & metrics collections.
   enabled: true
+  # metrics.port is the port on which the metrics server will listen.
   port: 3000
 
 dockerInDocker:
+  # dockerInDocker.enabled is used to enable or disable the Docker-in-Docker feature, which allows the mcpx deployment to run Docker containers inside the mcpx container.
   enabled: false
 
-controlPlane:
-  host: ""
-  streaming:
-    enabled: false
-  rest:
-    enabled: false
-
 config:
+  # config.mcpJson supplies content to the `mcp.json` file that contains the target MCP servers configuration.
   mcpJson: |
     {
       "mcpServers": {
@@ -62,6 +62,7 @@ config:
       }
     }
 
+  # config.appYaml supplies content to the `app.yaml` file that contains the application configuration.
   appYaml: |
     auth:
       enabled: false
@@ -69,3 +70,17 @@ config:
       base: "allow"
     toolExtensions:
       services: {}
+
+
+secretRef:
+  # secretRef.name is the name of the Kubernetes Secret that contains the sensitive data.
+  name: ""
+  # secretRef.keys is a list of keys in the Kubernetes Secret that should be made available as environment variables in the mcpx container.
+  keys: []
+
+controlPlane:
+  host: ""
+  streaming:
+    enabled: false
+  rest:
+    enabled: false

--- a/index.yaml
+++ b/index.yaml
@@ -2,17 +2,6 @@ apiVersion: v1
 entries:
   lunar-mcpx:
   - apiVersion: v2
-    appVersion: v0.1.4
-    created: "2025-06-24T18:00:27.947610278Z"
-    description: Helm chart for Lunar MCPX
-    digest: 093d7f8427ac10ff45ec89d8b0a31da873c1b3287c27c5208fc93280873794ad
-    icon: https://storage.googleapis.com/lunar-webapp-assets/favicon/apple-touch-icon.png
-    name: lunar-mcpx
-    type: application
-    urls:
-    - https://github.com/TheLunarCompany/proxy-helm-chart/releases/download/lunar-mcpx-v0.1.4/lunar-mcpx-v0.1.4.tgz
-    version: v0.1.4
-  - apiVersion: v2
     appVersion: v0.1.1
     created: "2025-06-23T07:13:22.573753536Z"
     description: Helm chart for Lunar MCPX


### PR DESCRIPTION
This PR:
* Ensures all values are documented on `values.yaml` with comments - best practice. K8s basics (e.g. `replicaCount`) are not documented, as well as `controlPlane` which is still not really ready for users usage.
* Updates README for MCPX Helm Chart - directing users to `values.yaml` to learn more about options (instead of chasing synchronization).
* Deletes mcpx 0.1.4 from `index.yaml` so it can be re-indexed (override release)