### PR TITLE
Adjusted ports to be 8080 in all services

### DIFF
--- a/charts/lunar-mcpx-webapp/templates/lunar-admin-ui-deployment.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-admin-ui-deployment.yaml
@@ -49,6 +49,8 @@ spec:
           env:
             - name: NODE_ENV
               value: "production"
+            - name: PORT
+              value: "8080"
           {{- if .Values.ingress.enabled }}
             - name: API_BASE_URL
               value: "https://{{ first .Values.ingress.domains.webserver }}"

--- a/charts/lunar-mcpx-webapp/templates/lunar-admin-ui-deployment.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-admin-ui-deployment.yaml
@@ -51,6 +51,8 @@ spec:
               value: "production"
             - name: PORT
               value: "8080"
+            - name: MCPX_UI_URL
+              value: "http://{{ include "lunar-mcpx-webapp.fullname" . }}-router:8080"
           {{- if .Values.ingress.enabled }}
             - name: API_BASE_URL
               value: "https://{{ first .Values.ingress.domains.webserver }}"

--- a/charts/lunar-mcpx-webapp/templates/lunar-admin-ui-deployment.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-admin-ui-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - name: mcpx-admin-container
           image: "{{ .Values.admin.image.repository }}:{{ .Values.admin.image.tag | default .Values.global.appVersion | default .Chart.AppVersion }}"
           ports:
-            - containerPort: 3000
+            - containerPort: 8080
           resources:
             {{- toYaml .Values.admin.resources | nindent 12 }}
           securityContext:
@@ -71,7 +71,7 @@ spec:
             failureThreshold: 30
             httpGet:
               path: /healthcheck
-              port: 3000
+              port: 8080
               scheme: HTTP
             periodSeconds: 10
           readinessProbe:
@@ -79,7 +79,7 @@ spec:
             failureThreshold: 3
             httpGet:
               path: /healthcheck
-              port: 3000
+              port: 8080
               scheme: HTTP
             periodSeconds: 10
             timeoutSeconds: 10
@@ -87,7 +87,7 @@ spec:
             failureThreshold: 3
             httpGet:
               path: /healthcheck
-              port: 3000
+              port: 8080
               scheme: HTTP
             periodSeconds: 10
             timeoutSeconds: 10

--- a/charts/lunar-mcpx-webapp/templates/lunar-admin-ui-service.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-admin-ui-service.yaml
@@ -14,7 +14,7 @@ spec:
     - name: admin80
       protocol: TCP
       port: 80
-      targetPort: 3000
+      targetPort: 8080
   sessionAffinity: ClientIP
   type: ClusterIP
   selector:

--- a/charts/lunar-mcpx-webapp/templates/lunar-admin-ui-service.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-admin-ui-service.yaml
@@ -41,7 +41,7 @@ spec:
     unhealthyThreshold: 3
     type: HTTP
     requestPath: /healthcheck
-    port: 3000
+    port: 8080
 {{- end }}
 {{- end }}
 

--- a/charts/lunar-mcpx-webapp/templates/lunar-auth-bff-deployment.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-auth-bff-deployment.yaml
@@ -54,7 +54,7 @@ spec:
         - name: mcpx-auth-container
           image: "{{ .Values.auth.image.repository }}:{{ .Values.auth.image.tag | default .Values.global.appVersion | default .Chart.AppVersion }}"
           ports:
-            - containerPort: 3000
+            - containerPort: 8080
           resources:
             {{- toYaml .Values.auth.resources | nindent 12 }}
           securityContext:
@@ -82,7 +82,7 @@ spec:
             - name: NODE_ENV
               value: "production"
             - name: PORT
-              value: "3000"
+              value: "8080"
           {{- if .Values.ingress.enabled }}
             - name: JWT_ISSUER
               value: "https://{{ first .Values.ingress.domains.auth }}"
@@ -101,7 +101,7 @@ spec:
             failureThreshold: 30
             httpGet:
               path: /healthcheck
-              port: 3000
+              port: 8080
               scheme: HTTP
             periodSeconds: 10
           readinessProbe:
@@ -109,7 +109,7 @@ spec:
             failureThreshold: 3
             httpGet:
               path: /healthcheck
-              port: 3000
+              port: 8080
               scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 10
@@ -118,7 +118,7 @@ spec:
             failureThreshold: 10
             httpGet:
               path: /healthcheck
-              port: 3000
+              port: 8080
               scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 30

--- a/charts/lunar-mcpx-webapp/templates/lunar-auth-bff-service.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-auth-bff-service.yaml
@@ -14,7 +14,7 @@ spec:
     - name: auth80
       protocol: TCP
       port: 80
-      targetPort: 3000
+      targetPort: 8080
   sessionAffinity: ClientIP
   type: ClusterIP
   selector:
@@ -41,7 +41,7 @@ spec:
     unhealthyThreshold: 3
     type: HTTP
     requestPath: /healthcheck
-    port: 3000
+    port: 8080
 {{- end }}
 {{- end }}
 

--- a/charts/lunar-mcpx-webapp/templates/lunar-common-ingress.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-common-ingress.yaml
@@ -59,7 +59,7 @@ spec:
               service:
                 name: {{ $xfullname }}-router
                 port:
-                  number: 5173
+                  number: 8080
             path: /
             pathType: Prefix
     {{ else }}

--- a/charts/lunar-mcpx-webapp/templates/lunar-hive-router-deployment.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-hive-router-deployment.yaml
@@ -22,12 +22,10 @@ spec:
         - name: mcpx-router-container
           image: "{{ .Values.router.image.repository }}:{{ .Values.router.image.tag | default .Values.global.appVersion | default .Chart.AppVersion }}"
           ports:
-            - containerPort: 5173
+            - containerPort: 8080
               name: ui
             - containerPort: 9000
               name: mcpx-server
-            - containerPort: 3000
-              name: metrics
           resources:
             {{- toYaml .Values.router.resources | nindent 12 }}
           envFrom:
@@ -80,23 +78,23 @@ spec:
             successThreshold: 1
             failureThreshold: 30
             httpGet:
-              path: /health
-              port: 5173
+              path: /healthcheck
+              port: 8080
               scheme: HTTP
             periodSeconds: 10
           readinessProbe:
             successThreshold: 1
             failureThreshold: 3
             httpGet:
-              path: /health
-              port: 5173
+              path: /healthcheck
+              port: 8080
               scheme: HTTP
             periodSeconds: 10
           livenessProbe:
             failureThreshold: 10
             httpGet:
-              path: /health
-              port: 5173
+              path: /healthcheck
+              port: 8080
               scheme: HTTP
             periodSeconds: 10
       volumes:

--- a/charts/lunar-mcpx-webapp/templates/lunar-hive-router-deployment.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-hive-router-deployment.yaml
@@ -50,6 +50,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: PORT
+              value: "8080"
             - name: RELEASE_NAMESPACE
               value: "{{ .Release.Namespace }}"
             - name: UI_SERVICE_NAME

--- a/charts/lunar-mcpx-webapp/templates/lunar-hive-router-service.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-hive-router-service.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- if eq .Values.ingress.type "gce" }}
     cloud.google.com/backend-config: '{"ports": {
       "router80": "{{ include "lunar-mcpx-webapp.fullname" . }}-router",
-      "ui5173": "{{ include "lunar-mcpx-webapp.fullname" . }}-router"
+      "ui8080": "{{ include "lunar-mcpx-webapp.fullname" . }}-router"
     }}'
     {{- end }}
     {{- end }}
@@ -17,9 +17,9 @@ spec:
     - name: router80
       port: 80
       targetPort: 9000
-    - name: ui5173
-      port: 5173
-      targetPort: 5173
+    - name: ui8080
+      port: 8080
+      targetPort: 8080
   sessionAffinity: ClientIP
   type: ClusterIP
   selector:
@@ -47,8 +47,8 @@ spec:
     healthyThreshold: 1
     unhealthyThreshold: 3
     type: HTTP
-    requestPath: /health
-    port: 5173
+    requestPath: /healthcheck
+    port: 8080
 {{- end }}
 {{- end }}
 

--- a/charts/lunar-mcpx-webapp/templates/lunar-hive-ui-deployment.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-hive-ui-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - name: mcpx-ui-container
           image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag }}"
           ports:
-            - containerPort: 5173
+            - containerPort: 8080
           resources:
             {{- toYaml .Values.ui.resources | nindent 12 }}
           envFrom:
@@ -43,6 +43,8 @@ spec:
           env:
             - name: VITE_ENABLE_ENTERPRISE
               value: "true"
+            - name: UI_PORT
+              value: "8080"
             - name: VITE_MCPX_SERVER_URL
               value: "https://{{ first .Values.ingress.domains.router }}"
           {{- if .Values.global.extraEnvVars }}
@@ -57,7 +59,7 @@ spec:
             failureThreshold: 30
             httpGet:
               path: /healthcheck
-              port: 5173
+              port: 8080
               scheme: HTTP
             periodSeconds: 10
           readinessProbe:
@@ -65,7 +67,7 @@ spec:
             failureThreshold: 3
             httpGet:
               path: /healthcheck
-              port: 5173
+              port: 8080
               scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 10
@@ -74,7 +76,7 @@ spec:
             failureThreshold: 10
             httpGet:
               path: /healthcheck
-              port: 5173
+              port: 8080
               scheme: HTTP
             initialDelaySeconds: 60
             periodSeconds: 30

--- a/charts/lunar-mcpx-webapp/templates/lunar-hive-ui-service.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-hive-ui-service.yaml
@@ -14,7 +14,7 @@ spec:
     - name: ui80
       protocol: TCP
       port: 80
-      targetPort: 5173
+      targetPort: 8080
   sessionAffinity: ClientIP
   type: ClusterIP
   selector:
@@ -41,7 +41,7 @@ spec:
     unhealthyThreshold: 3
     type: HTTP
     requestPath: /
-    port: 5173
+    port: 8080
 {{- end }}
 {{- end }}
 

--- a/charts/lunar-mcpx-webapp/templates/lunar-hub-deployment.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-hub-deployment.yaml
@@ -54,7 +54,7 @@ spec:
         - name: mcpx-hub-container
           image: "{{ .Values.hub.image.repository }}:{{ .Values.hub.image.tag | default .Values.global.appVersion | default .Chart.AppVersion }}"
           ports:
-            - containerPort: 3000
+            - containerPort: 8080
           resources:
             {{- toYaml .Values.hub.resources | nindent 12 }}
           securityContext:
@@ -81,6 +81,8 @@ spec:
           env:
             - name: NODE_ENV
               value: "production"
+            - name: PORT
+              value: "8080"
           {{- if .Values.global.extraEnvVars }}
           {{- include "lunar-mcpx-webapp.tplvalues.render" (dict "value" .Values.global.extraEnvVars "context" $) | nindent 12 }}
           {{- end }}
@@ -93,7 +95,7 @@ spec:
             failureThreshold: 30
             httpGet:
               path: /healthcheck
-              port: 3000
+              port: 8080
               scheme: HTTP
             periodSeconds: 10
           readinessProbe:
@@ -101,7 +103,7 @@ spec:
             failureThreshold: 3
             httpGet:
               path: /healthcheck
-              port: 3000
+              port: 8080
               scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 10
@@ -110,7 +112,7 @@ spec:
             failureThreshold: 3
             httpGet:
               path: /healthcheck
-              port: 3000
+              port: 8080
               scheme: HTTP
             initialDelaySeconds: 30
             periodSeconds: 10

--- a/charts/lunar-mcpx-webapp/templates/lunar-hub-service.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-hub-service.yaml
@@ -14,7 +14,7 @@ spec:
     - name: hub80
       protocol: TCP
       port: 80
-      targetPort: 3000
+      targetPort: 8080
   sessionAffinity: ClientIP
   type: ClusterIP
   selector:

--- a/charts/lunar-mcpx-webapp/templates/lunar-webserver-deployment.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-webserver-deployment.yaml
@@ -54,7 +54,7 @@ spec:
         - name: mcpx-webserver-container
           image: "{{ .Values.webserver.image.repository }}:{{ .Values.webserver.image.tag | default .Values.global.appVersion | default .Chart.AppVersion }}"
           ports:
-            - containerPort: 3000
+            - containerPort: 8080
           resources:
             {{- toYaml .Values.webserver.resources | nindent 12 }}
           securityContext:
@@ -81,6 +81,8 @@ spec:
           env:
             - name: NODE_ENV
               value: "production"
+            - name: PORT
+              value: "8080"
             - name: HIVE_CONTROLLER_URL
               value: http://{{ include "lunar-mcpx-webapp.fullname" . }}-controller
           {{- if .Values.ingress.enabled }}
@@ -99,7 +101,7 @@ spec:
             failureThreshold: 30
             httpGet:
               path: /healthcheck
-              port: 3000
+              port: 8080
               scheme: HTTP
             periodSeconds: 10
           readinessProbe:
@@ -107,7 +109,7 @@ spec:
             failureThreshold: 3
             httpGet:
               path: /healthcheck
-              port: 3000
+              port: 8080
               scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 10
@@ -116,7 +118,7 @@ spec:
             failureThreshold: 10
             httpGet:
               path: /healthcheck
-              port: 3000
+              port: 8080
               scheme: HTTP
             initialDelaySeconds: 60
             periodSeconds: 30

--- a/charts/lunar-mcpx-webapp/templates/lunar-webserver-service.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-webserver-service.yaml
@@ -14,7 +14,7 @@ spec:
     - name: webserver80
       protocol: TCP
       port: 80
-      targetPort: 3000
+      targetPort: 8080
     - name: webserver4000
       protocol: TCP
       port: 4000
@@ -45,7 +45,7 @@ spec:
     unhealthyThreshold: 3
     type: HTTP
     requestPath: /healthcheck
-    port: 3000
+    port: 8080
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
All services now uses PORT 8080 so we can always use the same convention for healthchecks