### PR TITLE
Release mcpx webapp tests

### DIFF
--- a/.github/workflows/release-mcpx-webapp-chart.yml
+++ b/.github/workflows/release-mcpx-webapp-chart.yml
@@ -78,6 +78,24 @@ jobs:
             sed -i.bak '/repository: .*mcpx-ui/,/tag: ""/s/tag: ""/tag: "${{ inputs.mcpx-version }}"/' charts/lunar-mcpx-webapp/values.yaml
           fi
 
+      # Run tests
+      - name: Run tests
+        shell: bash
+        run: |
+          mkdir /tmp/{test,bin}
+          wget -O /tmp/bin/yq https://github.com/mikefarah/yq/releases/download/v4.49.2/yq_linux_amd64
+          chmod 777 /tmp/bin/yq
+          echo "Rendering chart"
+          helm template test ./charts/lunar-mcpx-webapp/ > /tmp/test/chart-rendered.yaml
+          cat /tmp/test/chart-rendered.yaml
+          echo "Trying to get images"
+          IMAGES=$(/tmp/bin/yq '. | select(.kind=="Deployment") | .spec.template.spec.containers[0].image' /tmp/test/chart-rendered.yaml  | grep -v '\---')
+          echo "IMAGES=${IMAGES}"
+          for IMAGE in ${IMAGES}; do
+            echo "Verifying Image ${IMAGE}
+            docker pull ${IMAGE}
+          done
+
       # Commit the updated README.md if there are any changes
       - name: Commit updates
         run: |

--- a/.github/workflows/release-mcpx-webapp-chart.yml
+++ b/.github/workflows/release-mcpx-webapp-chart.yml
@@ -79,6 +79,11 @@ jobs:
           fi
 
       # Run tests
+      - name: Auth to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
       - name: Run tests
         shell: bash
         run: |
@@ -88,16 +93,15 @@ jobs:
           echo "Rendering chart"
           helm template test ./charts/lunar-mcpx-webapp/ > /tmp/test/chart-rendered.yaml
           cat /tmp/test/chart-rendered.yaml
-          echo "Trying to get images"
+          echo "Trying to pull images to make sure they are available in registry"
           IMAGES=$(/tmp/bin/yq '. | select(.kind=="Deployment") | .spec.template.spec.containers[0].image' /tmp/test/chart-rendered.yaml  | grep -v '\---')
           echo "IMAGES=${IMAGES}"
           for IMAGE in ${IMAGES}; do
             echo "Verifying Image ${IMAGE}"
+            gcloud auth configure-docker $(awk -F '/' {'print $1'} <<< ${IMAGE} ) --quiet
             docker pull ${IMAGE}
           done
-          
-          # TODO: TMP!
-          exit 1
+
       # Commit the updated README.md if there are any changes
       - name: Commit updates
         run: |

--- a/.github/workflows/release-mcpx-webapp-chart.yml
+++ b/.github/workflows/release-mcpx-webapp-chart.yml
@@ -92,10 +92,12 @@ jobs:
           IMAGES=$(/tmp/bin/yq '. | select(.kind=="Deployment") | .spec.template.spec.containers[0].image' /tmp/test/chart-rendered.yaml  | grep -v '\---')
           echo "IMAGES=${IMAGES}"
           for IMAGE in ${IMAGES}; do
-            echo "Verifying Image ${IMAGE}
+            echo "Verifying Image ${IMAGE}"
             docker pull ${IMAGE}
           done
-
+          
+          # TODO: TMP!
+          exit 1
       # Commit the updated README.md if there are any changes
       - name: Commit updates
         run: |

--- a/.github/workflows/release-mcpx-webapp-chart.yml
+++ b/.github/workflows/release-mcpx-webapp-chart.yml
@@ -84,15 +84,22 @@ jobs:
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
-      - name: Run tests
+      - name: Run tests - render
         shell: bash
         run: |
-          mkdir /tmp/{test,bin}
-          wget -O /tmp/bin/yq https://github.com/mikefarah/yq/releases/download/v4.49.2/yq_linux_amd64
-          chmod 777 /tmp/bin/yq
+          mkdir /tmp/test
+
           echo "Rendering chart"
           helm template test ./charts/lunar-mcpx-webapp/ > /tmp/test/chart-rendered.yaml
           cat /tmp/test/chart-rendered.yaml
+
+      - name: Run tests - pull images
+        shell: bash
+        run: |
+          mkdir /tmp/bin
+          wget -O /tmp/bin/yq https://github.com/mikefarah/yq/releases/download/v4.49.2/yq_linux_amd64
+          chmod 777 /tmp/bin/yq
+
           echo "Trying to pull images to make sure they are available in registry"
           IMAGES=$(/tmp/bin/yq '. | select(.kind=="Deployment") | .spec.template.spec.containers[0].image' /tmp/test/chart-rendered.yaml  | grep -v '\---')
           echo "IMAGES=${IMAGES}"


### PR DESCRIPTION
This PR implements additional step "Run tests" which is designed to make sure that helm template is render-able and docker images are available in registry