### PR TITLE
[mcpx-webapp] update vars to support current webserver env

### DIFF
--- a/charts/lunar-mcpx-webapp/templates/lunar-webserver-deployment.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-webserver-deployment.yaml
@@ -135,8 +135,10 @@ spec:
               value: "8080"
             - name: HIVE_CONTROLLER_URL
               value: "http://{{ include "lunar-mcpx-webapp.fullname" . }}-controller"
-            - name: HIVE_DEFAULT_MCPX_IMAGE
-              value: 'us-central1-docker.pkg.dev/prj-common-442813/mcpx/mcpx-server:{{ .Values.ui.image.tag | default (include "lunar-mcpx-webapp.mcpxVersion" .) }}'  
+            - name: HIVE_DEFAULT_MCPX_IMAGE_REPO
+              value: 'us-central1-docker.pkg.dev/prj-common-442813/mcpx/mcpx-server'
+            - name: HIVE_DEFAULT_MCPX_IMAGE_TAG
+              value: {{ .Values.ui.image.tag | default (include "lunar-mcpx-webapp.mcpxVersion" .) }}
           {{- if .Values.ingress.enabled }}
             - name: CORS_ALLOWED_ORIGINS
               value: "https://{{ first .Values.ingress.domains.admin }}"


### PR DESCRIPTION
Webserver now expects the mandatory `HIVE_DEFAULT_MCPX_IMAGE_TAG` and `HIVE_DEFAULT_MCPX_IMAGE_REPO` instead of `HIVE_DEFAULT_MCPX_IMAGE` which is no longer used

[[Application source PR](https://github.com/TheLunarCompany/lunar-private/pull/2385/files#diff-8cd7cf7722c40944796b02b64745491a1d1058b639dda57e5282e0ab2bf776c0)]