### PR TITLE
[mcpx-webapp] Support mcpx CRD schema validation env vars

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -27,3 +27,30 @@ jobs:
 
       - name: Run Helm unittest
         run: helm unittest ./charts/${{ matrix.chart }}
+
+  validate-crd-schema-version:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Validate CRD schema version matches values.yaml
+        run: |
+          CRD_VERSION=$(yq '.metadata.annotations["lunar.dev/schema-version"]' \
+            charts/lunar-mcpx-webapp/crds/crd-mcpx-instance.yaml)
+          VALUES_VERSION=$(yq '.controller.mcpxCRD.schemaExpectedVersion' \
+            charts/lunar-mcpx-webapp/values.yaml)
+
+          echo "CRD annotation: $CRD_VERSION"
+          echo "values.yaml default: $VALUES_VERSION"
+
+          if [ "$CRD_VERSION" != "$VALUES_VERSION" ]; then
+            echo "::error::CRD annotation lunar.dev/schema-version ($CRD_VERSION) != values.yaml controller.mcpxCRD.schemaExpectedVersion ($VALUES_VERSION)"
+            exit 1
+          fi
+          echo "Schema versions match: $CRD_VERSION"

--- a/charts/lunar-mcpx-webapp/crds/crd-mcpx-instance.yaml
+++ b/charts/lunar-mcpx-webapp/crds/crd-mcpx-instance.yaml
@@ -6,7 +6,7 @@ metadata:
     app: mcpx
     version: v1alpha1
   annotations:
-    lunar.dev/schema-version: "1"
+    lunar.dev/schema-version: "2"
 spec:
   group: hive.lunar.dev
   names:

--- a/charts/lunar-mcpx-webapp/crds/crd-mcpx-instance.yaml
+++ b/charts/lunar-mcpx-webapp/crds/crd-mcpx-instance.yaml
@@ -6,7 +6,7 @@ metadata:
     app: mcpx
     version: v1alpha1
   annotations:
-    lunar.dev/schema-version: "2"
+    lunar.dev/schema-version: "1"
 spec:
   group: hive.lunar.dev
   names:

--- a/charts/lunar-mcpx-webapp/templates/lunar-hive-controller-deployment.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-hive-controller-deployment.yaml
@@ -109,6 +109,10 @@ spec:
               value: ws://{{ include "lunar-mcpx-webapp.fullname" . }}-hub
             - name: UI_SERVICE_NAME
               value: "{{ include "lunar-mcpx-webapp.fullname" . }}-ui"
+            - name: MCPX_CRD_SCHEMA_VERSION_CHECK_STRICT
+              value: "{{ .Values.controller.mcpxCRD.schemaVersionStrictCheck | default true }}"
+            - name: MCPX_CRD_SCHEMA_EXPECTED_VERSION
+              value: "{{ .Values.controller.mcpxCRD.schemaExpectedVersion | default "1" }}"
           {{- if .Values.ingress.enabled }}
             - name: ROUTER_DOMAIN
               value: "https://{{ first .Values.ingress.domains.router }}"

--- a/charts/lunar-mcpx-webapp/values.schema.json
+++ b/charts/lunar-mcpx-webapp/values.schema.json
@@ -134,6 +134,27 @@
                 }
             }
         },
+        "controller": {
+            "type": "object",
+            "properties": {
+                "mcpxCRD": {
+                    "type": "object",
+                    "description": "Configuration for CRD schema version checks",
+                    "properties": {
+                        "schemaVersionStrictCheck": {
+                            "type": "boolean",
+                            "description": "Enable strict schema version checking",
+                            "default": true
+                        },
+                        "schemaExpectedVersion": {
+                            "type": "string",
+                            "description": "Expected CRD schema version",
+                            "default": "1"
+                        }
+                    }
+                }
+            }
+        },
         "webserver": {
             "type": "object",
             "properties": {

--- a/charts/lunar-mcpx-webapp/values.yaml
+++ b/charts/lunar-mcpx-webapp/values.yaml
@@ -275,6 +275,13 @@ controller:
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
 
+  # -- mcpxCRD configuration for CRD schema version checks
+  mcpxCRD:
+    # -- Enable strict schema version checking
+    schemaVersionStrictCheck: true
+    # -- Expected CRD schema version
+    schemaExpectedVersion: "1"
+
   # -- NodeSelector to pin pods in deployment to certain set of nodes.
   # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
   nodeSelector: {}


### PR DESCRIPTION
- Add CRD schema version configuration to hive-controller deployment
- New env vars: `MCPX_CRD_SCHEMA_EXPECTED_VERSION` and `MCPX_CRD_SCHEMA_VERSION_CHECK_STRICT`
- Configurable via `controller.mcpxCRD` in values.yaml
- Updated values.schema.json