### PR TITLE
[mcpx-webapp] allow MCPX image override via env vars

### DIFF
--- a/charts/lunar-mcpx-webapp/templates/lunar-webserver-deployment.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-webserver-deployment.yaml
@@ -135,12 +135,18 @@ spec:
               value: "8080"
             - name: HIVE_CONTROLLER_URL
               value: "http://{{ include "lunar-mcpx-webapp.fullname" . }}-controller"
-            - name: HIVE_DEFAULT_MCPX_IMAGE
-              value: 'us-central1-docker.pkg.dev/prj-common-442813/mcpx/mcpx-server:{{ .Values.ui.image.tag | default (include "lunar-mcpx-webapp.mcpxVersion" .) }}'
+            {{- $webserverExtraEnvNames := list }}
+            {{- range .Values.webserver.extraEnvVars }}
+            {{- $webserverExtraEnvNames = append $webserverExtraEnvNames .name }}
+            {{- end }}
+            {{- if not (has "HIVE_DEFAULT_MCPX_IMAGE_REPO" $webserverExtraEnvNames) }}
             - name: HIVE_DEFAULT_MCPX_IMAGE_REPO
               value: 'us-central1-docker.pkg.dev/prj-common-442813/mcpx/mcpx-server'
+            {{- end }}
+            {{- if not (has "HIVE_DEFAULT_MCPX_IMAGE_TAG" $webserverExtraEnvNames) }}
             - name: HIVE_DEFAULT_MCPX_IMAGE_TAG
               value: {{ .Values.ui.image.tag | default (include "lunar-mcpx-webapp.mcpxVersion" .) }}
+            {{- end }}
           {{- if .Values.ingress.enabled }}
             - name: CORS_ALLOWED_ORIGINS
               value: "https://{{ first .Values.ingress.domains.admin }}"


### PR DESCRIPTION
This PR allows overriding `HIVE_DEFAULT_MCPX_IMAGE_TAG` and `HIVE_DEFAULT_MCPX_IMAGE_REPO` in the Webserver of MCPX Webapp Chart, via `webserver.extraEnvVars` in the user supplied values.
Example for this section from top level:
```yaml
webserver:
  replicaCount: 1
  extraEnvVars:
    - name: HIVE_DEFAULT_MCPX_IMAGE_REPO
      value: "us-central1-docker.pkg.dev/prj-common-442813/mcpx-dev/mcpx-server" # for testing
    - name: HIVE_DEFAULT_MCPX_IMAGE_TAG
      value: "817e93f"
  extraEnvFromSecrets:
    - mcpx-webapp-analysis-llm      
  sandboxAnalysis:
    llmProvider: "google-gen-ai"
    llmModel: "gemini-2.5-flash"
```
