### PR TITLE
[mcpx-webapp] rollback (suspended cron)jobs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,8 @@
   ],
   "yaml.schemas": {
     "https://raw.githubusercontent.com/helm-unittest/helm-unittest/v0.8.2/schema/helm-testsuite.json": "file:///Users/eliavlavi/git/proxy-helm-chart/charts/lunar-mcpx/tests/configmap_test.yaml"
-  }
+  },
+  "yaml.validate": false,
+  "yaml.hover": true,
+  "yaml.completion": true
 }

--- a/charts/lunar-mcpx-webapp/README.tpl.md
+++ b/charts/lunar-mcpx-webapp/README.tpl.md
@@ -158,6 +158,51 @@ kubernetes secret
 - [Minimal non-production configuration with GCE ingress controller](examples/values-override/gcp-nonprod-demo.yaml)
 - [Production-like configuration with external secrets and external databases](examples/values-override/gcp-prod.yaml)
 
+### Admin DB Migration Jobs
+
+This chart includes four **suspended CronJobs** for DB migration management. They never run automatically — admins create one-off jobs from them using `kubectl create job`.
+
+> **Warning:** These jobs interact directly with the database. Use with caution and only when instructed!
+
+| CronJob | Purpose |
+|:--------|:--------|
+| `<release>-migrate-status` | Shows the current state of all migrations |
+| `<release>-migrate-rollback-dry` | Dry-run rollback (no changes are made) |
+| `<release>-migrate-rollback-execute` | **Executes** a rollback — this will modify the database |
+| `<release>-migrate-resolve-failed` | Marks a failed migration as resolved so Prisma can move past it |
+
+In the examples below, `<release>` is the full CronJob name prefix — composed of your Helm release name and the chart name (e.g. `mcpx-webapp`). Run `kubectl get cronjobs -n <namespace> | grep migrate` to find the exact names.
+
+**Check migration status:**
+```bash
+kubectl create job migrate-status-$(date +%s) \
+  --from=cronjob/<release>-migrate-status -n <namespace>
+```
+
+**Dry-run a rollback (safe, no DB changes):**
+```bash
+kubectl create job rollback-dry-$(date +%s) \
+  --from=cronjob/<release>-migrate-rollback-dry -n <namespace>
+```
+
+**Execute a rollback:**
+```bash
+kubectl create job rollback-$(date +%s) \
+  --from=cronjob/<release>-migrate-rollback-execute -n <namespace>
+```
+
+**Resolve a failed migration (allows Prisma to proceed on next deploy):**
+```bash
+kubectl create job resolve-failed-$(date +%s) \
+  --from=cronjob/<release>-migrate-resolve-failed -n <namespace>
+```
+
+> **Rollback vs. Resolve-failed:**
+> - **Rollback** is for when a migration ran successfully but is causing issues — the app is misbehaving, or you need to revert to a previous version for any reason. Rollback undoes the migration's changes to the database.
+> - **Resolve-failed** is for when a migration ran and failed. A failed migration blocks all future migrations from running. Since we use a forward-rolling strategy (we never delete migrations, even bad ones), resolving marks the failed migration as acknowledged so the next release — which should contain the fix — can run its migrations normally.
+
+By default, rollback targets the latest applied migration and resolve-failed targets the latest failed migration. To target a specific migration, set `jobs.admin.rollbackMigrationName` or `jobs.admin.resolveMigrationName` via Helm values override, apply it, and then create the job.
+
 ### Installation
 
 Minimal deployment with embedded Postgresql and Redis

--- a/charts/lunar-mcpx-webapp/templates/_admin-job-helpers.tpl
+++ b/charts/lunar-mcpx-webapp/templates/_admin-job-helpers.tpl
@@ -1,0 +1,104 @@
+{{/*
+Shared template for admin suspended CronJobs (migrate-status, migrate-rollback-dry, migrate-rollback-execute, migrate-resolve-failed).
+Expects a dict with keys:
+  - root: top-level Helm context (.)
+  - jobName: suffix for the CronJob name and labels
+  - command: list of strings for the container command
+  - extraEnv: list of {name, value} maps for additional env vars
+*/}}
+{{- define "lunar-mcpx-webapp.adminCronJob" -}}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "lunar-mcpx-webapp.fullname" .root }}-{{ .jobName }}
+  labels:
+    service: {{ include "lunar-mcpx-webapp.fullname" .root }}-{{ .jobName }}
+    {{- with .root.Values.global.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .root.Values.jobs.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  suspend: true
+  schedule: "0 0 31 2 *" # Feb 31 — a date that never exists, so even if accidentally un-suspended, it won't trigger
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      ttlSecondsAfterFinished: 86400
+      activeDeadlineSeconds: 3600
+      template:
+        metadata:
+          labels:
+            service: {{ include "lunar-mcpx-webapp.fullname" .root }}-{{ .jobName }}
+            {{- include "lunar-mcpx-webapp.selectorLabels" .root | nindent 12 }}
+            {{- with .root.Values.global.labels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .root.Values.jobs.labels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .root.Values.jobs.podLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: {{ .jobName }}
+              image: "{{ .root.Values.jobs.image.repository }}:{{ .root.Values.jobs.image.tag | default .root.Values.global.appVersion | default .root.Chart.AppVersion }}"
+              command: {{ .command | toJson }}
+              {{- if or (.root.Values.global.manageResources.limits) (.root.Values.global.manageResources.requests) }}
+              resources:
+                {{- if .root.Values.global.manageResources.limits }}
+                limits:
+                  {{- with .root.Values.jobs.resources.limits }}
+                  {{- toYaml . | nindent 18 }}
+                  {{- end }}
+                {{- end }}
+                {{- if .root.Values.global.manageResources.requests }}
+                requests:
+                  {{- with .root.Values.jobs.resources.requests }}
+                    {{- toYaml . | nindent 18 }}
+                    {{- end }}
+                {{- end }}
+              {{- end }}
+              envFrom:
+                - secretRef:
+                    name: {{ include "lunar-mcpx-webapp.fullname" .root }}-embedded
+              {{- with .root.Values.global.extraEnvFromSecrets }}
+              {{- range . }}
+                - secretRef:
+                    name: {{ . }}
+              {{- end }}
+              {{- end }}
+              {{- with .root.Values.jobs.extraEnvFromSecrets }}
+              {{- range . }}
+                - secretRef:
+                    name: {{ . }}
+              {{- end }}
+              {{- end }}
+              env:
+              {{- range .extraEnv }}
+              {{- if .value }}
+                - name: {{ .name }}
+                  value: {{ .value | quote }}
+              {{- end }}
+              {{- end }}
+              {{- if .root.Values.global.extraEnvVars }}
+              {{- include "lunar-mcpx-webapp.tplvalues.render" (dict "value" .root.Values.global.extraEnvVars "context" .root) | nindent 16 }}
+              {{- end }}
+              {{- if .root.Values.jobs.extraEnvVars }}
+              {{- include "lunar-mcpx-webapp.tplvalues.render" (dict "value" .root.Values.jobs.extraEnvVars "context" .root) | nindent 16 }}
+              {{- end }}
+
+          {{- with .root.Values.global.imagePullSecrets }}
+          imagePullSecrets:
+            {{- range . }}
+            - name: {{ . }}
+            {{- end }}
+          {{- end }}
+          {{- with .root.Values.jobs.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/charts/lunar-mcpx-webapp/templates/lunar-admin-migrate-resolve-failed-cronjob.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-admin-migrate-resolve-failed-cronjob.yaml
@@ -1,0 +1,9 @@
+---
+{{- include "lunar-mcpx-webapp.adminCronJob" (dict
+  "root" .
+  "jobName" "migrate-resolve-failed"
+  "command" (list "node" "dist/index.js" "migrate-resolve-failed")
+  "extraEnv" (list
+    (dict "name" "RESOLVE_MIGRATION_NAME" "value" .Values.jobs.admin.resolveMigrationName)
+  )
+) }}

--- a/charts/lunar-mcpx-webapp/templates/lunar-admin-migrate-rollback-dry-cronjob.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-admin-migrate-rollback-dry-cronjob.yaml
@@ -1,0 +1,10 @@
+---
+{{- include "lunar-mcpx-webapp.adminCronJob" (dict
+  "root" .
+  "jobName" "migrate-rollback-dry"
+  "command" (list "node" "dist/index.js" "migrate-rollback")
+  "extraEnv" (list
+    (dict "name" "ROLLBACK_DRY_RUN" "value" "true")
+    (dict "name" "ROLLBACK_MIGRATION_NAME" "value" .Values.jobs.admin.rollbackMigrationName)
+  )
+) }}

--- a/charts/lunar-mcpx-webapp/templates/lunar-admin-migrate-rollback-execute-cronjob.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-admin-migrate-rollback-execute-cronjob.yaml
@@ -1,0 +1,10 @@
+---
+{{- include "lunar-mcpx-webapp.adminCronJob" (dict
+  "root" .
+  "jobName" "migrate-rollback-execute"
+  "command" (list "node" "dist/index.js" "migrate-rollback")
+  "extraEnv" (list
+    (dict "name" "ROLLBACK_DRY_RUN" "value" "false")
+    (dict "name" "ROLLBACK_MIGRATION_NAME" "value" .Values.jobs.admin.rollbackMigrationName)
+  )
+) }}

--- a/charts/lunar-mcpx-webapp/templates/lunar-admin-migrate-status-cronjob.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-admin-migrate-status-cronjob.yaml
@@ -1,0 +1,7 @@
+---
+{{- include "lunar-mcpx-webapp.adminCronJob" (dict
+  "root" .
+  "jobName" "migrate-status"
+  "command" (list "node" "dist/index.js" "migrate-status")
+  "extraEnv" list
+) }}

--- a/charts/lunar-mcpx-webapp/values.schema.json
+++ b/charts/lunar-mcpx-webapp/values.schema.json
@@ -134,6 +134,27 @@
         }
       }
     },
+    "jobs": {
+      "type": "object",
+      "properties": {
+        "admin": {
+          "type": "object",
+          "description": "Admin job settings for DB migration management",
+          "properties": {
+            "rollbackMigrationName": {
+              "type": "string",
+              "description": "Target migration name for rollback. Leave empty unless explicitly instructed otherwise. When empty, rollback targets the latest applied migration.",
+              "default": ""
+            },
+            "resolveMigrationName": {
+              "type": "string",
+              "description": "Target migration name for resolve-failed. Leave empty unless explicitly instructed otherwise. When empty, resolves the latest failed migration.",
+              "default": ""
+            }
+          }
+        }
+      }
+    },
     "controller": {
       "type": "object",
       "properties": {

--- a/charts/lunar-mcpx-webapp/values.yaml
+++ b/charts/lunar-mcpx-webapp/values.yaml
@@ -504,6 +504,16 @@ jobs:
   #   label_2: value_2
   podLabels: {}
 
+  # -- Admin job settings for DB migration management.
+  # See the "Admin DB Migration Jobs" section in README.md for usage.
+  admin:
+    # -- Target migration name for rollback. Leave empty unless explicitly instructed otherwise.
+    # When empty, rollback targets the latest applied migration.
+    rollbackMigrationName: ""
+    # -- Target migration name for resolve-failed. Leave empty unless explicitly instructed otherwise.
+    # When empty, resolves the latest failed migration.
+    resolveMigrationName: ""
+
 ingress:
   # -- Enable or disable Ingress for mcpx-webapp services
   enabled: true


### PR DESCRIPTION
Helm chart support for the [companion PR](https://github.com/TheLunarCompany/lunar-private/pull/2626) that adds DB migration crisis management to mcpx-webapp.

Adds four **permanently-suspended CronJobs** that admins trigger manually via `kubectl create job --from=cronjob/...`:

| CronJob | Purpose |
|---------|---------|
| `migrate-status` | Report migration states |
| `migrate-rollback-dry` | Dry-run rollback (no DB changes) |
| `migrate-rollback-execute` | Execute a rollback |
| `migrate-resolve-failed` | Unblock deploys after a failed migration |

- Shared Helm template (`_admin-job-helpers.tpl`) to DRY up the four CronJob definitions — handles labels, image, resources, secrets, env vars, and node selectors
- CronJobs use an impossible schedule (`Feb 31`) so they never fire even if accidentally un-suspended
- Two new Helm values (`jobs.admin.rollbackMigrationName`, `jobs.admin.resolveMigrationName`) to optionally target a specific migration
- Values schema and README updated with usage instructions

## Test
Heavily tested on sandbox via the local changes to the charts