### PR TITLE
Changed the way we se the value of OIDC_JWKS_URI to be internal

### DIFF
--- a/charts/lunar-mcpx-webapp/README.md
+++ b/charts/lunar-mcpx-webapp/README.md
@@ -57,6 +57,8 @@ Required service versions:
 | OIDC_POST_LOGOUT_REDIRECT_URI |       |
 |       OIDC_ISSUER_URL         |       |
 
+Note: Router `OIDC_JWKS_URI` defaults to in-cluster auth service (`http://<release>-auth/.well-known/jwks.json`) and can be overridden with `router.oidcJwksUri`.
+
 #### Optional environmental variables
 
 

--- a/charts/lunar-mcpx-webapp/README.tpl.md
+++ b/charts/lunar-mcpx-webapp/README.tpl.md
@@ -57,6 +57,8 @@ Required service versions:
 | OIDC_POST_LOGOUT_REDIRECT_URI |       |
 |       OIDC_ISSUER_URL         |       |
 
+Note: Router `OIDC_JWKS_URI` defaults to in-cluster auth service (`http://<release>-auth/.well-known/jwks.json`) and can be overridden with `router.oidcJwksUri`.
+
 #### Optional environmental variables
 
 

--- a/charts/lunar-mcpx-webapp/templates/lunar-hive-router-deployment.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-hive-router-deployment.yaml
@@ -97,9 +97,10 @@ spec:
               value: "https://{{ first .Values.ingress.domains.ui }}"
             - name: WEBSERVER_URL
               value: "http://{{ include "lunar-mcpx-webapp.fullname" . }}-webserver:4000"
-          {{- if .Values.ingress.enabled }}
+            {{- $defaultOidcJwksUri := printf "http://%s-auth/.well-known/jwks.json" (include "lunar-mcpx-webapp.fullname" .) }}
             - name: OIDC_JWKS_URI
-              value: "https://{{ first .Values.ingress.domains.auth }}/.well-known/jwks.json"
+              value: {{ .Values.router.oidcJwksUri | default $defaultOidcJwksUri | quote }}
+          {{- if .Values.ingress.enabled }}
             - name: AUTH_BFF_URL
               value: "https://{{ first .Values.ingress.domains.auth }}"
           {{- end }}

--- a/charts/lunar-mcpx-webapp/values.yaml
+++ b/charts/lunar-mcpx-webapp/values.yaml
@@ -312,10 +312,6 @@ controller:
       cpu: "100m"
       memory: 128Mi
 
-  # -- Router-only override for JWKS URI used for bearer token validation.
-  # If empty, defaults to the in-cluster auth service URL.
-  oidcJwksUri: ""
-
   # -- extraEnvVars An array to add extra env vars
   # e.g:
   # extraEnvVars:
@@ -371,6 +367,10 @@ router:
     requests:
       cpu: "100m"
       memory: 128Mi
+
+  # -- Router-only override for JWKS URI used for bearer token validation.
+  # If empty, defaults to the in-cluster auth service URL.
+  oidcJwksUri: ""
 
   # -- extraEnvVars An array to add extra env vars
   # e.g:

--- a/charts/lunar-mcpx-webapp/values.yaml
+++ b/charts/lunar-mcpx-webapp/values.yaml
@@ -312,6 +312,10 @@ controller:
       cpu: "100m"
       memory: 128Mi
 
+  # -- Router-only override for JWKS URI used for bearer token validation.
+  # If empty, defaults to the in-cluster auth service URL.
+  oidcJwksUri: ""
+
   # -- extraEnvVars An array to add extra env vars
   # e.g:
   # extraEnvVars:


### PR DESCRIPTION
Fixes bearer-token auth failures behind self-signed ingress certificates by making router JWKS fetch use the in-cluster auth service by default.

### What changed
- Set router OIDC_JWKS_URI default to:
  - `http://<release>-auth/.well-known/jwks.json`
- Moved `OIDC_JWKS_URI` out of the ingress.enabled conditional so it is always configured.
- Kept `AUTH_BFF_URL` external and still gated by ingress settings.
- Added `router.oidcJwksUri` value for explicit override.
- Updated chart docs to mention the new default and override.
- 
### Why
`AUTH_BFF_URL` must stay external for discovery metadata and issuer matching, but JWKS retrieval should stay internal to avoid TLS trust issues with customer ingress certificates.