### PR TITLE
[mcpx-webapp] Admin friendly logs support

### DIFF
--- a/charts/lunar-mcpx-webapp/templates/lunar-hive-controller-rbac.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-hive-controller-rbac.yaml
@@ -41,6 +41,13 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Permissions for listing pods and reading pod logs
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/lunar-mcpx-webapp/templates/lunar-webserver-deployment.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-webserver-deployment.yaml
@@ -145,6 +145,8 @@ spec:
             - name: HIBERNATION_ENABLED
               value: "true"
             {{- end }}
+            - name: WEBAPP_DEPLOYMENT_PREFIX
+              value: {{ include "lunar-mcpx-webapp.fullname" . | quote }}
             {{- $webserverExtraEnvNames := list }}
             {{- range .Values.webserver.extraEnvVars }}
             {{- $webserverExtraEnvNames = append $webserverExtraEnvNames .name }}


### PR DESCRIPTION
Completes the work of [this PR](https://github.com/TheLunarCompany/lunar-private/pull/2673) by injecting the `WEBAPP_DEPLOYMENT_PREFIX` to Webserver (so it can construct deployments names correctly) + pod list and log fetch permissions