### PR TITLE
Add initContainer workaround for hive-ui file permissions on OpenShift

### DIFF
--- a/charts/lunar-mcpx-webapp/templates/lunar-hive-ui-deployment.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-hive-ui-deployment.yaml
@@ -43,11 +43,33 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
+      initContainers:
+        - name: copy-ui-files
+          image: '{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag | default (include "lunar-mcpx-webapp.mcpxVersion" .) }}'
+          command:
+            - sh
+            - -c
+            - |
+              cp -r /lunar/packages/ui/* /ui-temp/ || true
+              ls -la /ui-temp/
+          volumeMounts:
+            - name: config-dir
+              mountPath: /ui-temp
+      volumes:
+        - name: config-dir
+          emptyDir: {}
+      {{- end }}
       containers:
         - name: mcpx-ui-container
           image: '{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag | default (include "lunar-mcpx-webapp.mcpxVersion" .) }}'
           ports:
             - containerPort: 8080
+          {{- if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
+          volumeMounts:
+            - name: config-dir
+              mountPath: /lunar/packages/ui
+          {{- end }}
           {{- if or (.Values.global.manageResources.limits) (.Values.global.manageResources.requests) }}
           resources:
             {{- if .Values.global.manageResources.limits }}


### PR DESCRIPTION
The hive-ui container image runs as the  user (UID 1002), which owns the files under /lunar/packages/ui. On OpenShift, each container is assigned a UID from the namespace's allocated range by the restricted SCC, causing permission errors when the main container tries to write config.json into a directory owned by UID 1002.

This adds an OCP-only initContainer that copies /lunar/packages/ui into an emptyDir volume, which is then mounted over the original path in the main container. Because the initContainer and main container both run as the same namespace-assigned UID, the main container retains write access to the directory without needing to bind the pod to a less restrictive SCC (e.g. anyuid or nonroot-v2 with fsGroup).

The initContainer and volume are conditionally rendered only when the OpenShift security.openshift.io/v1 API is detected.