### PR TITLE
Conditionally omit runAsUser/runAsGroup on OpenShift

### DIFF
--- a/charts/lunar-mcpx-webapp/templates/lunar-admin-ui-deployment.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-admin-ui-deployment.yaml
@@ -67,8 +67,10 @@ spec:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+            {{- if not (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
             runAsUser: 1000
             runAsGroup: 1000
+            {{- end }}
           envFrom:
             - secretRef:
                 name: {{ include "lunar-mcpx-webapp.fullname" . }}-embedded

--- a/charts/lunar-mcpx-webapp/templates/lunar-auth-bff-deployment.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-auth-bff-deployment.yaml
@@ -117,8 +117,10 @@ spec:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+            {{- if not (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
             runAsUser: 1000
             runAsGroup: 1000
+            {{- end }}
           envFrom:
             - secretRef:
                 name: {{ include "lunar-mcpx-webapp.fullname" . }}-embedded

--- a/charts/lunar-mcpx-webapp/templates/lunar-hive-controller-deployment.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-hive-controller-deployment.yaml
@@ -46,9 +46,11 @@ spec:
       serviceAccountName: {{ include "lunar-mcpx-webapp.fullname" . }}-controller
       automountServiceAccountToken: true
       securityContext:
-        fsGroup: 2000
         runAsNonRoot: true
+        {{- if not (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
         runAsUser: 1000
+        fsGroup: 2000
+        {{- end }}
       containers:
         - name: mcpx-controller-container
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag | default .Values.global.appVersion | default .Chart.AppVersion }}"
@@ -73,8 +75,10 @@ spec:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+            {{- if not (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
             runAsUser: 1000
             runAsGroup: 1000
+            {{- end }}
           envFrom:
             - secretRef:
                 name: {{ include "lunar-mcpx-webapp.fullname" . }}-embedded

--- a/charts/lunar-mcpx-webapp/templates/lunar-hub-deployment.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-hub-deployment.yaml
@@ -112,8 +112,10 @@ spec:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+            {{- if not (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
             runAsUser: 1000
             runAsGroup: 1000
+            {{- end }}
           envFrom:
             - secretRef:
                 name: {{ include "lunar-mcpx-webapp.fullname" . }}-embedded

--- a/charts/lunar-mcpx-webapp/templates/lunar-webserver-deployment.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-webserver-deployment.yaml
@@ -112,8 +112,10 @@ spec:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+            {{- if not ( .Capabilities.APIVersions.Has "security.openshift.io/v1")  }}
             runAsUser: 1000
             runAsGroup: 1000
+            {{- end }}
           envFrom:
             - secretRef:
                 name: {{ include "lunar-mcpx-webapp.fullname" . }}-embedded


### PR DESCRIPTION
OpenShift's restricted SCC enforces that runAs values fall within the UID/GID ranges allocated to the namespace and rejects pods that specify values outside that range. Use .Capabilities.APIVersions to detect the security.openshift.io/v1 API at deploy time and skip rendering runAsUser, runAsGroup, and fsGroup when running on OpenShift, allowing the SCC to assign values from the namespace's allocated range.

Affected templates:
- lunar-admin-ui-deployment
- lunar-auth-bff-deployment
- lunar-hive-controller-deployment
- lunar-hub-deployment
- lunar-webserver-deployment