### PR TITLE
CatalogItemStore jobs

### DIFF
--- a/charts/lunar-mcpx-webapp/README.tpl.md
+++ b/charts/lunar-mcpx-webapp/README.tpl.md
@@ -212,6 +212,60 @@ kubectl create job resolve-failed-$(date +%s) \
 
 By default, rollback targets the latest applied migration and resolve-failed targets the latest failed migration. To target a specific migration, set `jobs.admin.rollbackMigrationName` or `jobs.admin.resolveMigrationName` via Helm values override, apply it, and then create the job.
 
+### Catalog Item Store Jobs
+
+This chart includes three **suspended CronJobs** for managing catalog items from the built-in store. Like the migration jobs above, they never run automatically — admins create one-off jobs from them using `kubectl create job`.
+
+| CronJob | Purpose |
+|:--------|:--------|
+| `<release>-catalog-list` | Lists all store items and their status relative to the DB (already present, customized, missing, etc.) |
+| `<release>-catalog-populate` | Inserts new catalog items from the store into the DB |
+| `<release>-catalog-fix` | Updates existing DB catalog items with the latest store definitions |
+
+**List all store catalog items and their status:**
+```bash
+kubectl create job catalog-list-$(date +%s) \
+  --from=cronjob/<release>-catalog-list -n <namespace>
+```
+
+**Populate new catalog items from the store:**
+
+First, set `jobs.admin.catalogItemStore.catalogItemNames` to the desired items, apply the Helm values, then create the job:
+```yaml
+jobs:
+  admin:
+    catalogItemStore:
+      catalogItemNames:
+        - slack
+        - github
+        - linear
+```
+```bash
+kubectl create job catalog-populate-$(date +%s) \
+  --from=cronjob/<release>-catalog-populate -n <namespace>
+```
+
+**Fix (update) existing catalog items from the store:**
+
+Set `catalogItemNames` the same way. Optionally set `forceOverride` to `true` to replace DB config entirely instead of merging:
+```yaml
+jobs:
+  admin:
+    catalogItemStore:
+      catalogItemNames:
+        - slack
+        - github
+      forceOverride: true
+```
+```bash
+kubectl create job catalog-fix-$(date +%s) \
+  --from=cronjob/<release>-catalog-fix -n <namespace>
+```
+
+> **Merge vs. Force Override:**
+> - **Default (merge):** metadata fields (`displayName`, `description`, `repoUrl`, `docsUrl`) are overwritten from the store. For stdio config, `command` and `args` are overridden from the store; for env, only new keys are added — existing admin customizations are preserved. For remote config, `url` is overridden; for headers, only new keys are added.
+> - **Force override (`forceOverride: true`):** the entire config is replaced with the store template, discarding all admin customizations.
+
 ### Hibernation Cron Schedule
 
 Use `hibernation.cronSchedule` to control when the `hibernate-instances` CronJob runs.

--- a/charts/lunar-mcpx-webapp/templates/lunar-admin-catalog-fix-cronjob.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-admin-catalog-fix-cronjob.yaml
@@ -1,0 +1,10 @@
+---
+{{- include "lunar-mcpx-webapp.adminCronJob" (dict
+  "root" .
+  "jobName" "catalog-fix"
+  "command" (list "node" "dist/index.js" "fix-catalog-item-from-store")
+  "extraEnv" (list
+    (dict "name" "CATALOG_ITEM_NAMES" "value" (.Values.jobs.admin.catalogItemStore.catalogItemNames | join ","))
+    (dict "name" "FORCE_OVERRIDE" "value" .Values.jobs.admin.catalogItemStore.forceOverride)
+  )
+) }}

--- a/charts/lunar-mcpx-webapp/templates/lunar-admin-catalog-list-cronjob.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-admin-catalog-list-cronjob.yaml
@@ -1,0 +1,7 @@
+---
+{{- include "lunar-mcpx-webapp.adminCronJob" (dict
+  "root" .
+  "jobName" "catalog-list"
+  "command" (list "node" "dist/index.js" "list-store-catalog-items")
+  "extraEnv" list
+) }}

--- a/charts/lunar-mcpx-webapp/templates/lunar-admin-catalog-populate-cronjob.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-admin-catalog-populate-cronjob.yaml
@@ -1,0 +1,9 @@
+---
+{{- include "lunar-mcpx-webapp.adminCronJob" (dict
+  "root" .
+  "jobName" "catalog-populate"
+  "command" (list "node" "dist/index.js" "populate-catalog-item-from-store")
+  "extraEnv" (list
+    (dict "name" "CATALOG_ITEM_NAMES" "value" (.Values.jobs.admin.catalogItemStore.catalogItemNames | join ","))
+  )
+) }}

--- a/charts/lunar-mcpx-webapp/tests/catalog_item_store_jobs_test.yaml
+++ b/charts/lunar-mcpx-webapp/tests/catalog_item_store_jobs_test.yaml
@@ -40,10 +40,10 @@ tests:
           path: spec.jobTemplate.spec.template.spec.containers[0].command
           value: ["node", "dist/index.js", "fix-catalog-item-from-store"]
 
-  - it: catalog-populate should not set env vars when list is empty
+  - it: catalog-populate should not set CATALOG_ITEM_NAMES when list is empty
     template: templates/lunar-admin-catalog-populate-cronjob.yaml
     asserts:
-      - isNull:
+      - isEmpty:
           path: spec.jobTemplate.spec.template.spec.containers[0].env
 
   - it: catalog-populate should join catalogItemNames into comma-separated env var

--- a/charts/lunar-mcpx-webapp/tests/catalog_item_store_jobs_test.yaml
+++ b/charts/lunar-mcpx-webapp/tests/catalog_item_store_jobs_test.yaml
@@ -1,0 +1,92 @@
+suite: Catalog Item Store Jobs
+templates:
+  - templates/lunar-admin-catalog-list-cronjob.yaml
+  - templates/lunar-admin-catalog-populate-cronjob.yaml
+  - templates/lunar-admin-catalog-fix-cronjob.yaml
+
+tests:
+  - it: all three jobs should be suspended CronJobs
+    asserts:
+      - isKind:
+          of: CronJob
+      - equal:
+          path: spec.suspend
+          value: true
+
+  - it: all three jobs should use the impossible Feb 31 schedule
+    asserts:
+      - equal:
+          path: spec.schedule
+          value: "0 0 31 2 *"
+
+  - it: catalog-list should run list-store-catalog-items command
+    template: templates/lunar-admin-catalog-list-cronjob.yaml
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].command
+          value: ["node", "dist/index.js", "list-store-catalog-items"]
+
+  - it: catalog-populate should run populate-catalog-item-from-store command
+    template: templates/lunar-admin-catalog-populate-cronjob.yaml
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].command
+          value: ["node", "dist/index.js", "populate-catalog-item-from-store"]
+
+  - it: catalog-fix should run fix-catalog-item-from-store command
+    template: templates/lunar-admin-catalog-fix-cronjob.yaml
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].command
+          value: ["node", "dist/index.js", "fix-catalog-item-from-store"]
+
+  - it: catalog-populate should not set env vars when list is empty
+    template: templates/lunar-admin-catalog-populate-cronjob.yaml
+    asserts:
+      - isNull:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+
+  - it: catalog-populate should join catalogItemNames into comma-separated env var
+    template: templates/lunar-admin-catalog-populate-cronjob.yaml
+    set:
+      jobs.admin.catalogItemStore.catalogItemNames:
+        - slack
+        - github
+        - linear
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: CATALOG_ITEM_NAMES
+            value: "slack,github,linear"
+
+  - it: catalog-fix should set both CATALOG_ITEM_NAMES and FORCE_OVERRIDE
+    template: templates/lunar-admin-catalog-fix-cronjob.yaml
+    set:
+      jobs.admin.catalogItemStore.catalogItemNames:
+        - slack
+        - redis
+      jobs.admin.catalogItemStore.forceOverride: true
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: CATALOG_ITEM_NAMES
+            value: "slack,redis"
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: FORCE_OVERRIDE
+            value: "true"
+
+  - it: catalog-fix should not set FORCE_OVERRIDE when empty
+    template: templates/lunar-admin-catalog-fix-cronjob.yaml
+    set:
+      jobs.admin.catalogItemStore.catalogItemNames:
+        - slack
+    asserts:
+      - notContains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: FORCE_OVERRIDE
+          any: true

--- a/charts/lunar-mcpx-webapp/values.schema.json
+++ b/charts/lunar-mcpx-webapp/values.schema.json
@@ -169,6 +169,25 @@
               "type": "string",
               "description": "Target migration name for resolve-failed. Leave empty unless explicitly instructed otherwise. When empty, resolves the latest failed migration.",
               "default": ""
+            },
+            "catalogItemStore": {
+              "type": "object",
+              "description": "Catalog Item Store jobs settings",
+              "properties": {
+                "catalogItemNames": {
+                  "type": "array",
+                  "description": "Catalog item names for populate/fix jobs.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "default": []
+                },
+                "forceOverride": {
+                  "type": "boolean",
+                  "description": "Set to true to force-override existing config in fix job. Default merges non-destructively.",
+                  "default": false
+                }
+              }
             }
           }
         }

--- a/charts/lunar-mcpx-webapp/values.yaml
+++ b/charts/lunar-mcpx-webapp/values.yaml
@@ -615,6 +615,19 @@ jobs:
     # When empty, resolves the latest failed migration.
     resolveMigrationName: ""
 
+    # -- Catalog Item Store jobs settings.
+    # See the "Catalog Item Store Jobs" section in README.md for usage.
+    catalogItemStore:
+      # -- Catalog item names for populate/fix jobs.
+      # Example:
+      #   catalogItemNames:
+      #     - slack
+      #     - github
+      #     - linear
+      catalogItemNames: []
+      # -- Set to true to force-override existing config in fix job. Default merges non-destructively.
+      forceOverride: false
+
 hibernation:
   # Cron schedule for the scheduled hibernation job (e.g. "0 22 * * *").
   # Leave empty to disable the CronJob.


### PR DESCRIPTION
This PR adds three new suspended CronJobs for managing catalog items from the built-in store: `catalog-list`, `catalog-populate`, and `catalog-fix`. Same pattern as the existing migration admin jobs — they never run on a schedule, admins create one-off jobs from them via `kubectl create job`.

- **catalog-list** — lists all store items and their status relative to the DB
- **catalog-populate** — inserts new catalog items from the store into the DB, takes a list of item names
- **catalog-fix** — updates existing DB items with latest store definitions, supports a `forceOverride` flag to replace config entirely instead of merging

All three reuse the existing `adminCronJob` helper. Config is passed through env vars (`CATALOG_ITEM_NAMES` as comma-separated, `FORCE_OVERRIDE` as boolean). Helm values, JSON schema, and README docs are included. Also added a helm-unittest suite covering all three jobs.

See applicative PR [here](https://github.com/TheLunarCompany/lunar-private/pull/2714)