### PR TITLE
[mcpx-webapp] Clickhouse Integration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(helm template:*)"
+    ]
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "cSpell.words": [
+    "clickhouse",
     "datadoghq",
     "mcpx",
     "Millis",

--- a/charts/lunar-mcpx-webapp/README.md
+++ b/charts/lunar-mcpx-webapp/README.md
@@ -254,7 +254,7 @@ The chart can deploy an embedded single-node ClickHouse instance for event store
    ```
 
 When enabled, the chart will:
-- Deploy a ClickHouse StatefulSet with a persistent volume (default 50Gi)
+- Deploy a ClickHouse StatefulSet with a persistent volume (default 10Gi)
 - Create a ClusterIP service on port 8123
 - Add a ClickHouse migration init container to both hub and webserver (runs after the Prisma migration)
 - Inject `CLICKHOUSE_URL` into hub and webserver main containers

--- a/charts/lunar-mcpx-webapp/README.md
+++ b/charts/lunar-mcpx-webapp/README.md
@@ -295,41 +295,6 @@ Use `hibernation.cronSchedule` to control when the `hibernate-instances` CronJob
     cronSchedule: "*/5 * * * *"
   ```
 
-### ClickHouse (Event Store Analytics)
-
-The chart can deploy an embedded single-node ClickHouse instance for event store analytics. ClickHouse is cluster-internal only and is **not** exposed outside the cluster.
-
-#### Prerequisites
-
-1. Create a Kubernetes secret containing ClickHouse credentials:
-   ```bash
-   kubectl create secret generic ch-creds -n <namespace> \
-     --from-literal=CLICKHOUSE_USER=default \
-     --from-literal=CLICKHOUSE_PASSWORD='<strong-password>'
-   ```
-
-2. Enable ClickHouse and reference the secret in your values override:
-   ```yaml
-   clickhouse:
-     enabled: true
-     credentialsSecret: ch-creds
-   ```
-
-When enabled, the chart will:
-- Deploy a ClickHouse StatefulSet with a persistent volume (default 10Gi)
-- Create a ClusterIP service on port 8123
-- Add a ClickHouse migration init container to both hub and webserver (runs after the Prisma migration)
-- Inject `CLICKHOUSE_URL` into hub and webserver main containers
-
-If `clickhouse.enabled` is `true` but the credentials secret is missing or misconfigured, hub and webserver pods will fail to start (`CreateContainerConfigError`). This is intentional — it prevents the application from running without a valid ClickHouse connection.
-
-#### REPL access (debugging)
-
-```bash
-kubectl exec -it <release>-clickhouse-0 -n <namespace> -- clickhouse-client \
-  --user <user> --password <password>
-```
-
 ### Installation
 
 Minimal deployment with embedded Postgresql and Redis

--- a/charts/lunar-mcpx-webapp/README.md
+++ b/charts/lunar-mcpx-webapp/README.md
@@ -233,6 +233,41 @@ Use `hibernation.cronSchedule` to control when the `hibernate-instances` CronJob
     cronSchedule: "*/5 * * * *"
   ```
 
+### ClickHouse (Event Store Analytics)
+
+The chart can deploy an embedded single-node ClickHouse instance for event store analytics. ClickHouse is cluster-internal only and is **not** exposed outside the cluster.
+
+#### Prerequisites
+
+1. Create a Kubernetes secret containing ClickHouse credentials:
+   ```bash
+   kubectl create secret generic ch-creds -n <namespace> \
+     --from-literal=CLICKHOUSE_USER=default \
+     --from-literal=CLICKHOUSE_PASSWORD='<strong-password>'
+   ```
+
+2. Enable ClickHouse and reference the secret in your values override:
+   ```yaml
+   clickhouse:
+     enabled: true
+     credentialsSecret: ch-creds
+   ```
+
+When enabled, the chart will:
+- Deploy a ClickHouse StatefulSet with a persistent volume (default 50Gi)
+- Create a ClusterIP service on port 8123
+- Add a ClickHouse migration init container to both hub and webserver (runs after the Prisma migration)
+- Inject `CLICKHOUSE_URL` into hub and webserver main containers
+
+If `clickhouse.enabled` is `true` but the credentials secret is missing or misconfigured, hub and webserver pods will fail to start (`CreateContainerConfigError`). This is intentional — it prevents the application from running without a valid ClickHouse connection.
+
+#### REPL access (debugging)
+
+```bash
+kubectl exec -it <release>-clickhouse-0 -n <namespace> -- clickhouse-client \
+  --user <user> --password <password>
+```
+
 ### Installation
 
 Minimal deployment with embedded Postgresql and Redis

--- a/charts/lunar-mcpx-webapp/README.tpl.md
+++ b/charts/lunar-mcpx-webapp/README.tpl.md
@@ -295,6 +295,41 @@ Use `hibernation.cronSchedule` to control when the `hibernate-instances` CronJob
     cronSchedule: "*/5 * * * *"
   ```
 
+### ClickHouse (Event Store Analytics)
+
+The chart can deploy an embedded single-node ClickHouse instance for event store analytics. ClickHouse is cluster-internal only and is **not** exposed outside the cluster.
+
+#### Prerequisites
+
+1. Create a Kubernetes secret containing ClickHouse credentials:
+   ```bash
+   kubectl create secret generic ch-creds -n <namespace> \
+     --from-literal=CLICKHOUSE_USER=default \
+     --from-literal=CLICKHOUSE_PASSWORD='<strong-password>'
+   ```
+
+2. Enable ClickHouse and reference the secret in your values override:
+   ```yaml
+   clickhouse:
+     enabled: true
+     credentialsSecret: ch-creds
+   ```
+
+When enabled, the chart will:
+- Deploy a ClickHouse StatefulSet with a persistent volume (default 10Gi)
+- Create a ClusterIP service on port 8123
+- Add a ClickHouse migration init container to both hub and webserver (runs after the Prisma migration)
+- Inject `CLICKHOUSE_URL` into hub and webserver main containers
+
+If `clickhouse.enabled` is `true` but the credentials secret is missing or empty, `helm install` will fail with a schema validation error.
+
+#### REPL access (debugging)
+
+```bash
+kubectl exec -it <release>-clickhouse-0 -n <namespace> -- clickhouse-client \
+  --user <user> --password <password>
+```
+
 ### Installation
 
 Minimal deployment with embedded Postgresql and Redis

--- a/charts/lunar-mcpx-webapp/templates/_helpers.tpl
+++ b/charts/lunar-mcpx-webapp/templates/_helpers.tpl
@@ -74,6 +74,14 @@ Renders a value that contains template.
 Usage:
 {{ include "lunar-mcpx-webapp.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $) }}
 */}}
+{{/*
+ClickHouse connection URL built at runtime via K8s variable substitution.
+CLICKHOUSE_USER and CLICKHOUSE_PASSWORD must be available via envFrom.
+*/}}
+{{- define "lunar-mcpx-webapp.clickhouseUrl" -}}
+http://$(CLICKHOUSE_USER):$(CLICKHOUSE_PASSWORD)@{{ include "lunar-mcpx-webapp.fullname" . }}-clickhouse:8123
+{{- end }}
+
 {{- define "lunar-mcpx-webapp.tplvalues.render" -}}
     {{- if typeIs "string" .value }}
         {{- tpl .value .context }}

--- a/charts/lunar-mcpx-webapp/templates/clickhouse-service.yaml
+++ b/charts/lunar-mcpx-webapp/templates/clickhouse-service.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.clickhouse.enabled | default false }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lunar-mcpx-webapp.fullname" . }}-clickhouse
+  labels:
+    name: {{ include "lunar-mcpx-webapp.fullname" . }}-clickhouse
+    app: {{ include "lunar-mcpx-webapp.fullname" . }}-clickhouse
+    {{- with .Values.global.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.clickhouse.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  ports:
+    - name: clickhouse
+      protocol: TCP
+      port: 8123
+      targetPort: 8123
+  type: ClusterIP
+  selector:
+    app: {{ include "lunar-mcpx-webapp.fullname" . }}-clickhouse
+    {{- include "lunar-mcpx-webapp.selectorLabels" . | nindent 4 }}
+    {{- with .Values.global.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.clickhouse.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.clickhouse.podLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/lunar-mcpx-webapp/templates/clickhouse-statefulset.yaml
+++ b/charts/lunar-mcpx-webapp/templates/clickhouse-statefulset.yaml
@@ -51,11 +51,17 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ .Values.clickhouse.credentialsSecret }}
+          {{- if or (.Values.global.manageResources.limits) (.Values.global.manageResources.requests) }}
           resources:
+            {{- if .Values.global.manageResources.requests }}
             requests:
               {{- toYaml .Values.clickhouse.resources.requests | nindent 14 }}
+            {{- end }}
+            {{- if .Values.global.manageResources.limits }}
             limits:
               {{- toYaml .Values.clickhouse.resources.limits | nindent 14 }}
+            {{- end }}
+          {{- end }}
           ports:
             - containerPort: 8123
           volumeMounts:

--- a/charts/lunar-mcpx-webapp/templates/clickhouse-statefulset.yaml
+++ b/charts/lunar-mcpx-webapp/templates/clickhouse-statefulset.yaml
@@ -1,0 +1,103 @@
+{{- if .Values.clickhouse.enabled | default false }}
+{{- $tolerations := concat .Values.global.tolerations .Values.clickhouse.tolerations -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "lunar-mcpx-webapp.fullname" . }}-clickhouse
+  labels:
+    name: {{ include "lunar-mcpx-webapp.fullname" . }}-clickhouse
+    app: {{ include "lunar-mcpx-webapp.fullname" . }}-clickhouse
+    {{- with .Values.global.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.clickhouse.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "lunar-mcpx-webapp.fullname" . }}-clickhouse
+      {{- include "lunar-mcpx-webapp.selectorLabels" . | nindent 6 }}
+      {{- with .Values.global.labels }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- with .Values.clickhouse.labels }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- with .Values.clickhouse.podLabels }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+  serviceName: clickhouse
+  # Single-node ClickHouse — deliberately not scaled; one replica handles event store analytics.
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ include "lunar-mcpx-webapp.fullname" . }}-clickhouse
+        {{- include "lunar-mcpx-webapp.selectorLabels" . | nindent 8 }}
+        {{- with .Values.global.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.clickhouse.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.clickhouse.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      containers:
+        - name: clickhouse
+          image: clickhouse/clickhouse-server:24.8-alpine
+          envFrom:
+            - secretRef:
+                name: {{ .Values.clickhouse.credentialsSecret }}
+          resources:
+            requests:
+              {{- toYaml .Values.clickhouse.resources.requests | nindent 14 }}
+            limits:
+              {{- toYaml .Values.clickhouse.resources.limits | nindent 14 }}
+          ports:
+            - containerPort: 8123
+          volumeMounts:
+            {{- if .Values.clickhouse.persistence.enabled | default false }}
+            - name: data
+              mountPath: /var/lib/clickhouse
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: 8123
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: 8123
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+      {{- with .Values.clickhouse.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if .Values.clickhouse.persistence.enabled | default false }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          {{- toYaml .Values.clickhouse.persistence.accessModes | nindent 10 }}
+        {{- with .Values.clickhouse.persistence.storageClassName }}
+        storageClassName: {{ . }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.clickhouse.persistence.size }}
+  {{- end }}
+
+{{- end }}

--- a/charts/lunar-mcpx-webapp/templates/clickhouse-statefulset.yaml
+++ b/charts/lunar-mcpx-webapp/templates/clickhouse-statefulset.yaml
@@ -27,7 +27,7 @@ spec:
       {{- with .Values.clickhouse.podLabels }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
-  serviceName: clickhouse
+  serviceName: {{ include "lunar-mcpx-webapp.fullname" . }}-clickhouse
   # Single-node ClickHouse — deliberately not scaled; one replica handles event store analytics.
   replicas: 1
   template:
@@ -47,7 +47,8 @@ spec:
     spec:
       containers:
         - name: clickhouse
-          image: clickhouse/clickhouse-server:24.8-alpine
+          image: "{{ .Values.clickhouse.image.repository }}:{{ .Values.clickhouse.image.tag }}"
+          imagePullPolicy: {{ .Values.clickhouse.image.pullPolicy }}
           envFrom:
             - secretRef:
                 name: {{ .Values.clickhouse.credentialsSecret }}

--- a/charts/lunar-mcpx-webapp/templates/lunar-hub-deployment.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-hub-deployment.yaml
@@ -88,6 +88,34 @@ spec:
           {{- include "lunar-mcpx-webapp.tplvalues.render" (dict "value" .Values.hub.extraEnvVars "context" $) | nindent 12 }}
           {{- end }}
 
+        {{- if .Values.clickhouse.enabled }}
+        - name: mcpx-hub-clickhouse-migration
+          image: "{{ .Values.hub.image.repository }}:{{ .Values.hub.image.tag | default .Values.global.appVersion | default .Chart.AppVersion }}"
+          {{- if or (.Values.global.manageResources.limits) (.Values.global.manageResources.requests) }}
+          resources:
+            {{- if .Values.global.manageResources.limits }}
+            limits:
+              {{- with .Values.hub.resources.limits }}
+              {{- toYaml . | nindent 14 }}
+              {{- end }}
+            {{- end }}
+            {{- if .Values.global.manageResources.requests }}
+            requests:
+              {{- with .Values.hub.resources.requests }}
+                {{- toYaml . | nindent 14 }}
+                {{- end }}
+            {{- end }}
+          {{- end }}
+          command: ["/bin/sh"]
+          args: ["-c", "cd /mcpx-webapp && CLICKHOUSE_URL={{ include "lunar-mcpx-webapp.clickhouseUrl" . }} node packages/toolkit-clickhouse/dist/bin/migrate.js"]
+          envFrom:
+            - secretRef:
+                name: {{ .Values.clickhouse.credentialsSecret }}
+          env:
+            - name: NODE_ENV
+              value: "production"
+        {{- end }}
+
       containers:
         - name: mcpx-hub-container
           image: "{{ .Values.hub.image.repository }}:{{ .Values.hub.image.tag | default .Values.global.appVersion | default .Chart.AppVersion }}"
@@ -129,6 +157,10 @@ spec:
                 name: {{ . }}
           {{- end }}
           {{- end }}
+          {{- if .Values.clickhouse.enabled }}
+            - secretRef:
+                name: {{ .Values.clickhouse.credentialsSecret }}
+          {{- end }}
           env:
             - name: NODE_ENV
               value: "production"
@@ -140,6 +172,10 @@ spec:
             {{- end }}
             - name: PORT
               value: "8080"
+            {{- if .Values.clickhouse.enabled }}
+            - name: CLICKHOUSE_URL
+              value: "{{ include "lunar-mcpx-webapp.clickhouseUrl" . }}"
+            {{- end }}
           {{- if .Values.global.extraEnvVars }}
           {{- include "lunar-mcpx-webapp.tplvalues.render" (dict "value" .Values.global.extraEnvVars "context" $) | nindent 12 }}
           {{- end }}

--- a/charts/lunar-mcpx-webapp/templates/lunar-hub-deployment.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-hub-deployment.yaml
@@ -107,7 +107,7 @@ spec:
             {{- end }}
           {{- end }}
           command: ["/bin/sh"]
-          args: ["-c", "cd /mcpx-webapp && CLICKHOUSE_URL={{ include "lunar-mcpx-webapp.clickhouseUrl" . }} node packages/toolkit-clickhouse/dist/bin/migrate.js"]
+          args: ["-c", "cd /mcpx-webapp && CLICKHOUSE_URL='{{ include "lunar-mcpx-webapp.clickhouseUrl" . }}' node packages/toolkit-clickhouse/dist/bin/migrate.js"]
           envFrom:
             - secretRef:
                 name: {{ .Values.clickhouse.credentialsSecret }}

--- a/charts/lunar-mcpx-webapp/templates/lunar-webserver-deployment.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-webserver-deployment.yaml
@@ -107,7 +107,7 @@ spec:
             {{- end }}
           {{- end }}
           command: ["/bin/sh"]
-          args: ["-c", "cd /mcpx-webapp && CLICKHOUSE_URL={{ include "lunar-mcpx-webapp.clickhouseUrl" . }} node packages/toolkit-clickhouse/dist/bin/migrate.js"]
+          args: ["-c", "cd /mcpx-webapp && CLICKHOUSE_URL='{{ include "lunar-mcpx-webapp.clickhouseUrl" . }}' node packages/toolkit-clickhouse/dist/bin/migrate.js"]
           envFrom:
             - secretRef:
                 name: {{ .Values.clickhouse.credentialsSecret }}

--- a/charts/lunar-mcpx-webapp/templates/lunar-webserver-deployment.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-webserver-deployment.yaml
@@ -88,6 +88,34 @@ spec:
           {{- include "lunar-mcpx-webapp.tplvalues.render" (dict "value" .Values.webserver.extraEnvVars "context" $) | nindent 12 }}
           {{- end }}
 
+        {{- if .Values.clickhouse.enabled }}
+        - name: mcpx-webserver-clickhouse-migration
+          image: "{{ .Values.webserver.image.repository }}:{{ .Values.webserver.image.tag | default .Values.global.appVersion | default .Chart.AppVersion }}"
+          {{- if or (.Values.global.manageResources.limits) (.Values.global.manageResources.requests) }}
+          resources:
+            {{- if .Values.global.manageResources.limits }}
+            limits:
+              {{- with .Values.webserver.resources.limits }}
+              {{- toYaml . | nindent 14 }}
+              {{- end }}
+            {{- end }}
+            {{- if .Values.global.manageResources.requests }}
+            requests:
+              {{- with .Values.webserver.resources.requests }}
+                {{- toYaml . | nindent 14 }}
+                {{- end }}
+            {{- end }}
+          {{- end }}
+          command: ["/bin/sh"]
+          args: ["-c", "cd /mcpx-webapp && CLICKHOUSE_URL={{ include "lunar-mcpx-webapp.clickhouseUrl" . }} node packages/toolkit-clickhouse/dist/bin/migrate.js"]
+          envFrom:
+            - secretRef:
+                name: {{ .Values.clickhouse.credentialsSecret }}
+          env:
+            - name: NODE_ENV
+              value: "production"
+        {{- end }}
+
       containers:
         - name: mcpx-webserver-container
           image: "{{ .Values.webserver.image.repository }}:{{ .Values.webserver.image.tag | default .Values.global.appVersion | default .Chart.AppVersion }}"
@@ -129,6 +157,10 @@ spec:
                 name: {{ . }}
           {{- end }}
           {{- end }}
+          {{- if .Values.clickhouse.enabled }}
+            - secretRef:
+                name: {{ .Values.clickhouse.credentialsSecret }}
+          {{- end }}
           env:
             - name: NODE_ENV
               value: "production"
@@ -140,6 +172,10 @@ spec:
             {{- end }}
             - name: PORT
               value: "8080"
+            {{- if .Values.clickhouse.enabled }}
+            - name: CLICKHOUSE_URL
+              value: "{{ include "lunar-mcpx-webapp.clickhouseUrl" . }}"
+            {{- end }}
             - name: HIVE_CONTROLLER_URL
               value: "http://{{ include "lunar-mcpx-webapp.fullname" . }}-controller"
             {{- if .Values.hibernation.cronSchedule }}

--- a/charts/lunar-mcpx-webapp/tests/clickhouse_hub_deployment_test.yaml
+++ b/charts/lunar-mcpx-webapp/tests/clickhouse_hub_deployment_test.yaml
@@ -1,0 +1,83 @@
+suite: Hub deployment ClickHouse integration
+templates:
+  - templates/lunar-hub-deployment.yaml
+
+tests:
+  - it: should not render clickhouse init container when disabled
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.initContainers
+          count: 1
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: mcpx-hub-prisma-migration
+
+  - it: should add clickhouse migration init container when enabled
+    set:
+      clickhouse.enabled: true
+      clickhouse.credentialsSecret: ch-creds
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.initContainers
+          count: 2
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: mcpx-hub-clickhouse-migration
+
+  - it: should reference credentials secret in init container envFrom
+    set:
+      clickhouse.enabled: true
+      clickhouse.credentialsSecret: my-ch-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[1].envFrom
+          content:
+            secretRef:
+              name: my-ch-secret
+
+  - it: should run clickhouse migration script in init container
+    set:
+      clickhouse.enabled: true
+      clickhouse.credentialsSecret: ch-creds
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[1].args[1]
+          pattern: "node packages/toolkit-clickhouse/dist/bin/migrate.js"
+
+  - it: should add credentials secret to main container envFrom when enabled
+    set:
+      clickhouse.enabled: true
+      clickhouse.credentialsSecret: ch-creds
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: ch-creds
+
+  - it: should not add credentials secret to main container envFrom when disabled
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: ch-creds
+
+  - it: should add CLICKHOUSE_URL env var to main container when enabled
+    set:
+      clickhouse.enabled: true
+      clickhouse.credentialsSecret: ch-creds
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CLICKHOUSE_URL
+          any: true
+
+  - it: should not add CLICKHOUSE_URL env var when disabled
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CLICKHOUSE_URL
+          any: true

--- a/charts/lunar-mcpx-webapp/tests/clickhouse_service_test.yaml
+++ b/charts/lunar-mcpx-webapp/tests/clickhouse_service_test.yaml
@@ -1,0 +1,33 @@
+suite: ClickHouse Service
+templates:
+  - templates/clickhouse-service.yaml
+
+tests:
+  - it: should not render when clickhouse is disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render ClusterIP service when clickhouse is enabled
+    set:
+      clickhouse.enabled: true
+      clickhouse.credentialsSecret: ch-creds
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.type
+          value: ClusterIP
+
+  - it: should expose port 8123
+    set:
+      clickhouse.enabled: true
+      clickhouse.credentialsSecret: ch-creds
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: clickhouse
+            protocol: TCP
+            port: 8123
+            targetPort: 8123

--- a/charts/lunar-mcpx-webapp/tests/clickhouse_statefulset_test.yaml
+++ b/charts/lunar-mcpx-webapp/tests/clickhouse_statefulset_test.yaml
@@ -1,0 +1,191 @@
+suite: ClickHouse StatefulSet
+templates:
+  - templates/clickhouse-statefulset.yaml
+
+tests:
+  - it: should not render when clickhouse is disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render StatefulSet when clickhouse is enabled
+    set:
+      clickhouse.enabled: true
+      clickhouse.credentialsSecret: ch-creds
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: spec.replicas
+          value: 1
+      - equal:
+          path: spec.serviceName
+          value: clickhouse
+
+  - it: should use correct image
+    set:
+      clickhouse.enabled: true
+      clickhouse.credentialsSecret: ch-creds
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: clickhouse/clickhouse-server:24.8-alpine
+
+  - it: should reference credentials secret in envFrom
+    set:
+      clickhouse.enabled: true
+      clickhouse.credentialsSecret: my-ch-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: my-ch-secret
+
+  - it: should expose port 8123
+    set:
+      clickhouse.enabled: true
+      clickhouse.credentialsSecret: ch-creds
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            containerPort: 8123
+
+  - it: should configure health probes on /ping
+    set:
+      clickhouse.enabled: true
+      clickhouse.credentialsSecret: ch-creds
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /ping
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 8123
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /ping
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 8123
+
+  - it: should mount persistent volume at /var/lib/clickhouse
+    set:
+      clickhouse.enabled: true
+      clickhouse.credentialsSecret: ch-creds
+      clickhouse.persistence.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: data
+            mountPath: /var/lib/clickhouse
+
+  - it: should create volumeClaimTemplate with defaults
+    set:
+      clickhouse.enabled: true
+      clickhouse.credentialsSecret: ch-creds
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.name
+          value: data
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.accessModes
+          value:
+            - ReadWriteOnce
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
+          value: 10Gi
+
+  - it: should allow overriding persistence size
+    set:
+      clickhouse.enabled: true
+      clickhouse.credentialsSecret: ch-creds
+      clickhouse.persistence.size: 100Gi
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
+          value: 100Gi
+
+  - it: should set storageClassName when provided
+    set:
+      clickhouse.enabled: true
+      clickhouse.credentialsSecret: ch-creds
+      clickhouse.persistence.storageClassName: premium-rwo
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: premium-rwo
+
+  - it: should not set storageClassName when empty
+    set:
+      clickhouse.enabled: true
+      clickhouse.credentialsSecret: ch-creds
+    asserts:
+      - isNull:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+
+  - it: should not create volumeClaimTemplate when persistence disabled
+    set:
+      clickhouse.enabled: true
+      clickhouse.credentialsSecret: ch-creds
+      clickhouse.persistence.enabled: false
+    asserts:
+      - isNull:
+          path: spec.volumeClaimTemplates
+
+  - it: should set default resource requests and limits
+    set:
+      clickhouse.enabled: true
+      clickhouse.credentialsSecret: ch-creds
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 4096Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 2000m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 8192Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 4000m
+
+  - it: should apply nodeSelector when set
+    set:
+      clickhouse.enabled: true
+      clickhouse.credentialsSecret: ch-creds
+      clickhouse.nodeSelector:
+        disktype: ssd
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector.disktype
+          value: ssd
+
+  - it: should merge global and clickhouse tolerations
+    set:
+      clickhouse.enabled: true
+      clickhouse.credentialsSecret: ch-creds
+      global.tolerations:
+        - key: "global-key"
+          operator: "Exists"
+          effect: "NoSchedule"
+      clickhouse.tolerations:
+        - key: "ch-key"
+          operator: "Exists"
+          effect: "NoSchedule"
+    asserts:
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: "global-key"
+            operator: "Exists"
+            effect: "NoSchedule"
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: "ch-key"
+            operator: "Exists"
+            effect: "NoSchedule"

--- a/charts/lunar-mcpx-webapp/tests/clickhouse_statefulset_test.yaml
+++ b/charts/lunar-mcpx-webapp/tests/clickhouse_statefulset_test.yaml
@@ -20,9 +20,9 @@ tests:
           value: 1
       - equal:
           path: spec.serviceName
-          value: clickhouse
+          value: RELEASE-NAME-lunar-mcpx-webapp-clickhouse
 
-  - it: should use correct image
+  - it: should use default image
     set:
       clickhouse.enabled: true
       clickhouse.credentialsSecret: ch-creds
@@ -30,6 +30,24 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].image
           value: clickhouse/clickhouse-server:24.8-alpine
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent
+
+  - it: should allow overriding image repo, tag, and pullPolicy
+    set:
+      clickhouse.enabled: true
+      clickhouse.credentialsSecret: ch-creds
+      clickhouse.image.repository: my-mirror.example.com/clickhouse
+      clickhouse.image.tag: 24.9-alpine
+      clickhouse.image.pullPolicy: Always
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: my-mirror.example.com/clickhouse:24.9-alpine
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
 
   - it: should reference credentials secret in envFrom
     set:

--- a/charts/lunar-mcpx-webapp/tests/clickhouse_statefulset_test.yaml
+++ b/charts/lunar-mcpx-webapp/tests/clickhouse_statefulset_test.yaml
@@ -145,13 +145,13 @@ tests:
           value: 4096Mi
       - equal:
           path: spec.template.spec.containers[0].resources.requests.cpu
-          value: 2000m
+          value: 4000m
       - equal:
           path: spec.template.spec.containers[0].resources.limits.memory
           value: 8192Mi
       - equal:
           path: spec.template.spec.containers[0].resources.limits.cpu
-          value: 4000m
+          value: 8000m
 
   - it: should apply nodeSelector when set
     set:

--- a/charts/lunar-mcpx-webapp/tests/clickhouse_statefulset_test.yaml
+++ b/charts/lunar-mcpx-webapp/tests/clickhouse_statefulset_test.yaml
@@ -153,6 +153,16 @@ tests:
           path: spec.template.spec.containers[0].resources.limits.cpu
           value: 8000m
 
+  - it: should not render resources when manageResources is disabled
+    set:
+      clickhouse.enabled: true
+      clickhouse.credentialsSecret: ch-creds
+      global.manageResources.limits: false
+      global.manageResources.requests: false
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].resources
+
   - it: should apply nodeSelector when set
     set:
       clickhouse.enabled: true

--- a/charts/lunar-mcpx-webapp/tests/clickhouse_webserver_deployment_test.yaml
+++ b/charts/lunar-mcpx-webapp/tests/clickhouse_webserver_deployment_test.yaml
@@ -1,0 +1,83 @@
+suite: Webserver deployment ClickHouse integration
+templates:
+  - templates/lunar-webserver-deployment.yaml
+
+tests:
+  - it: should not render clickhouse init container when disabled
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.initContainers
+          count: 1
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: mcpx-webserver-prisma-migration
+
+  - it: should add clickhouse migration init container when enabled
+    set:
+      clickhouse.enabled: true
+      clickhouse.credentialsSecret: ch-creds
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.initContainers
+          count: 2
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: mcpx-webserver-clickhouse-migration
+
+  - it: should reference credentials secret in init container envFrom
+    set:
+      clickhouse.enabled: true
+      clickhouse.credentialsSecret: my-ch-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[1].envFrom
+          content:
+            secretRef:
+              name: my-ch-secret
+
+  - it: should run clickhouse migration script in init container
+    set:
+      clickhouse.enabled: true
+      clickhouse.credentialsSecret: ch-creds
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[1].args[1]
+          pattern: "node packages/toolkit-clickhouse/dist/bin/migrate.js"
+
+  - it: should add credentials secret to main container envFrom when enabled
+    set:
+      clickhouse.enabled: true
+      clickhouse.credentialsSecret: ch-creds
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: ch-creds
+
+  - it: should not add credentials secret to main container envFrom when disabled
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: ch-creds
+
+  - it: should add CLICKHOUSE_URL env var to main container when enabled
+    set:
+      clickhouse.enabled: true
+      clickhouse.credentialsSecret: ch-creds
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CLICKHOUSE_URL
+          any: true
+
+  - it: should not add CLICKHOUSE_URL env var when disabled
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CLICKHOUSE_URL
+          any: true

--- a/charts/lunar-mcpx-webapp/values.schema.json
+++ b/charts/lunar-mcpx-webapp/values.schema.json
@@ -137,6 +137,84 @@
         }
       }
     },
+    "clickhouse": {
+      "type": "object",
+      "description": "Embedded ClickHouse for event store analytics",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable embedded ClickHouse StatefulSet",
+          "default": false
+        },
+        "credentialsSecret": {
+          "type": "string",
+          "description": "Name of the K8s secret containing CLICKHOUSE_USER and CLICKHOUSE_PASSWORD",
+          "default": ""
+        },
+        "nodeSelector": {
+          "type": "object"
+        },
+        "tolerations": {
+          "type": "array"
+        },
+        "labels": {
+          "type": "object"
+        },
+        "podLabels": {
+          "type": "object"
+        },
+        "persistence": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": true
+            },
+            "accessModes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "storageClassName": {
+              "type": "string",
+              "default": ""
+            },
+            "size": {
+              "type": "string",
+              "default": "10Gi"
+            }
+          }
+        },
+        "resources": {
+          "type": "object",
+          "properties": {
+            "requests": {
+              "type": "object",
+              "properties": {
+                "memory": {
+                  "type": "string"
+                },
+                "cpu": {
+                  "type": "string"
+                }
+              }
+            },
+            "limits": {
+              "type": "object",
+              "properties": {
+                "memory": {
+                  "type": "string"
+                },
+                "cpu": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "postgres": {
       "type": "object",
       "properties": {

--- a/charts/lunar-mcpx-webapp/values.schema.json
+++ b/charts/lunar-mcpx-webapp/values.schema.json
@@ -144,6 +144,18 @@
     "clickhouse": {
       "type": "object",
       "description": "Embedded ClickHouse for event store analytics",
+      "if": {
+        "properties": {
+          "enabled": { "const": true }
+        },
+        "required": ["enabled"]
+      },
+      "then": {
+        "properties": {
+          "credentialsSecret": { "minLength": 1 }
+        },
+        "required": ["credentialsSecret"]
+      },
       "properties": {
         "enabled": {
           "type": "boolean",
@@ -152,8 +164,22 @@
         },
         "credentialsSecret": {
           "type": "string",
-          "description": "Name of the K8s secret containing CLICKHOUSE_USER and CLICKHOUSE_PASSWORD",
+          "description": "Name of the K8s secret containing CLICKHOUSE_USER and CLICKHOUSE_PASSWORD. Required when enabled is true.",
           "default": ""
+        },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            },
+            "pullPolicy": {
+              "type": "string"
+            }
+          }
         },
         "nodeSelector": {
           "type": "object"

--- a/charts/lunar-mcpx-webapp/values.yaml
+++ b/charts/lunar-mcpx-webapp/values.yaml
@@ -842,6 +842,13 @@ clickhouse:
   enabled: false
   # -- Name of the K8s secret containing CLICKHOUSE_USER and CLICKHOUSE_PASSWORD
   credentialsSecret: ""
+  image:
+    # -- ClickHouse image repository
+    repository: clickhouse/clickhouse-server
+    # -- ClickHouse image tag
+    tag: 24.8-alpine
+    # -- ClickHouse image pull policy
+    pullPolicy: IfNotPresent
   nodeSelector: {}
   tolerations: []
   labels: {}

--- a/charts/lunar-mcpx-webapp/values.yaml
+++ b/charts/lunar-mcpx-webapp/values.yaml
@@ -762,6 +762,32 @@ redis:
   persistence:
     enabled: true
 
+clickhouse:
+  # -- Enable embedded ClickHouse for event store analytics.
+  # Requires a pre-existing K8s secret with CLICKHOUSE_USER and CLICKHOUSE_PASSWORD keys.
+  enabled: false
+  # -- Name of the K8s secret containing CLICKHOUSE_USER and CLICKHOUSE_PASSWORD
+  credentialsSecret: ""
+  nodeSelector: {}
+  tolerations: []
+  labels: {}
+  podLabels: {}
+  persistence:
+    enabled: true
+    accessModes:
+      - ReadWriteOnce
+    storageClassName: ""
+    size: 10Gi
+  # -- Resource defaults: CH docs recommend 4 CPU / 8Gi RAM as practical minimum for small workloads.
+  # Requests are set to half (2 CPU / 4Gi) for burst headroom.
+  resources:
+    requests:
+      memory: "4096Mi"
+      cpu: "2000m"
+    limits:
+      memory: "8192Mi"
+      cpu: "4000m"
+
 monitor:
   prometheus:
     # -- Enable or disable MPCX monitoring with Prometheus

--- a/charts/lunar-mcpx-webapp/values.yaml
+++ b/charts/lunar-mcpx-webapp/values.yaml
@@ -778,15 +778,15 @@ clickhouse:
       - ReadWriteOnce
     storageClassName: ""
     size: 10Gi
-  # -- Resource defaults: CH docs recommend 4 CPU / 8Gi RAM as practical minimum for small workloads.
-  # Requests are set to half (2 CPU / 4Gi) for burst headroom.
+  # -- Resource defaults: CH docs recommend 4 CPU / 8Gi RAM as practical minimum.
+  # Limits set to 2x requests for burst headroom.
   resources:
     requests:
       memory: "4096Mi"
-      cpu: "2000m"
+      cpu: "4000m"
     limits:
       memory: "8192Mi"
-      cpu: "4000m"
+      cpu: "8000m"
 
 monitor:
   prometheus:


### PR DESCRIPTION
This PR adds an **optional**, **embedded single-node** ClickHouse deployment to the mcpx-webapp chart for event store analytics.

When `clickhouse.enabled: true`:
- A ClickHouse StatefulSet (pinned to `24.8-alpine`) is deployed with a ClusterIP service on port 8123 — cluster-internal only, not exposed externally
- Both hub and webserver get a ClickHouse migration init container that runs `packages/toolkit-clickhouse/dist/bin/migrate.js` after the existing Prisma migration
- `CLICKHOUSE_URL` is injected into hub and webserver main containers, built at runtime via K8s variable substitution from a user-provided credentials secret
- Persistence defaults to 10Gi with `ReadWriteOnce`, configurable via `clickhouse.persistence.*`
- Resource defaults follow CH recommendations: 4 CPU / 4Gi RAM requests, 2x limits for burst. Gated behind global.manageResources like the rest of the chart.

The credentials secret (k8s secret including `CLICKHOUSE_USER` + `CLICKHOUSE_PASSWORD`) **must be created by the client beforehand** (@RotemY-Lunar FYI). If `clickhouse.enabled` is true but the secret is missing, pods will fail with `CreateContainerConfigError` — this is intentional to avoid running without a valid CH connection.

Also includes:
- Values schema additions for the new `clickhouse` block
- Helm unit tests covering the StatefulSet, service, and hub/webserver deployment integration (init containers, envFrom, env vars, enabled/disabled states, tolerations merging, persistence options)
- README section with setup instructions and REPL access snippet
