### PR TITLE
Lunar mcpx webapp cronjob validation

### DIFF
--- a/charts/lunar-mcpx-webapp/README.md
+++ b/charts/lunar-mcpx-webapp/README.md
@@ -162,6 +162,29 @@ kubectl create secret generic {{ name_of_cert }} -n {{ mcpx_namespace }} --from-
 Note: In case when multiple CA certificates should be added, concat all of them in the same file and import as a single
 kubernetes secret
 
+### Naming / `fullnameOverride` length limit
+
+Kubernetes enforces a **63 character limit** for many resource names (DNS label, e.g. `metadata.name` for `Service`, `Deployment`, `Secret`, etc.).
+
+This chart builds many resource names by taking the chart **fullname** (from your Helm release name + optional `nameOverride`/`fullnameOverride`) and appending a suffix, for example:
+
+- `<fullname>-webserver`
+- `<fullname>-controller`
+- `<fullname>-embedded`
+
+Because the suffix is appended **after** the fullname is computed, the fullname itself must leave room for that suffix.
+
+**Recommended rule:** keep `fullnameOverride` **≤ 53 characters**.
+
+Why 53? One common suffix in this chart is `-webserver` which is 10 characters (including the leading `-`).  
+So the safe max base length is \(63 - 10 = 53\).
+
+If you set `fullnameOverride` longer than that, installs/upgrades may fail with errors similar to:
+
+- `metadata.name: Invalid value: "...": must be no more than 63 characters`
+
+**How to fix:** choose a shorter `fullnameOverride` (or a shorter Helm release name), then run `helm upgrade` again.
+
 #### GCP
 
 - [Minimal non-production configuration with GCE ingress controller](examples/values-override/gcp-nonprod-demo.yaml)

--- a/charts/lunar-mcpx-webapp/README.tpl.md
+++ b/charts/lunar-mcpx-webapp/README.tpl.md
@@ -162,6 +162,29 @@ kubectl create secret generic {{ name_of_cert }} -n {{ mcpx_namespace }} --from-
 Note: In case when multiple CA certificates should be added, concat all of them in the same file and import as a single
 kubernetes secret
 
+### Naming / `fullnameOverride` length limit
+
+Kubernetes enforces a **63 character limit** for many resource names (DNS label, e.g. `metadata.name` for `Service`, `Deployment`, `Secret`, etc.).
+
+This chart builds many resource names by taking the chart **fullname** (from your Helm release name + optional `nameOverride`/`fullnameOverride`) and appending a suffix, for example:
+
+- `<fullname>-webserver`
+- `<fullname>-controller`
+- `<fullname>-embedded`
+
+Because the suffix is appended **after** the fullname is computed, the fullname itself must leave room for that suffix.
+
+**Recommended rule:** keep `fullnameOverride` **≤ 53 characters**.
+
+Why 53? One common suffix in this chart is `-webserver` which is 10 characters (including the leading `-`).  
+So the safe max base length is \(63 - 10 = 53\).
+
+If you set `fullnameOverride` longer than that, installs/upgrades may fail with errors similar to:
+
+- `metadata.name: Invalid value: "...": must be no more than 63 characters`
+
+**How to fix:** choose a shorter `fullnameOverride` (or a shorter Helm release name), then run `helm upgrade` again.
+
 #### GCP
 
 - [Minimal non-production configuration with GCE ingress controller](examples/values-override/gcp-nonprod-demo.yaml)

--- a/charts/lunar-mcpx-webapp/templates/_admin-job-helpers.tpl
+++ b/charts/lunar-mcpx-webapp/templates/_admin-job-helpers.tpl
@@ -11,9 +11,9 @@ Expects a dict with keys:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ include "lunar-mcpx-webapp.fullname" .root }}-{{ .jobName }}
+  name: {{ include "lunar-mcpx-webapp.cronJobBaseName" .root }}-{{ .jobName }}
   labels:
-    service: {{ include "lunar-mcpx-webapp.fullname" .root }}-{{ .jobName }}
+    service: {{ include "lunar-mcpx-webapp.cronJobBaseName" .root }}-{{ .jobName }}
     {{- with .root.Values.global.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -31,7 +31,7 @@ spec:
       template:
         metadata:
           labels:
-            service: {{ include "lunar-mcpx-webapp.fullname" .root }}-{{ .jobName }}
+            service: {{ include "lunar-mcpx-webapp.cronJobBaseName" .root }}-{{ .jobName }}
             {{- include "lunar-mcpx-webapp.selectorLabels" .root | nindent 12 }}
             {{- with .root.Values.global.labels }}
             {{- toYaml . | nindent 12 }}

--- a/charts/lunar-mcpx-webapp/templates/_helpers.tpl
+++ b/charts/lunar-mcpx-webapp/templates/_helpers.tpl
@@ -81,3 +81,37 @@ Usage:
         {{- tpl (.value | toYaml) .context }}
     {{- end }}
 {{- end -}}
+
+{{/*
+CronJob base name.
+Returns cronJobBaseName if set, otherwise falls back to the standard fullname.
+*/}}
+{{- define "lunar-mcpx-webapp.cronJobBaseName" -}}
+{{- if .Values.cronJobBaseName -}}
+  {{- .Values.cronJobBaseName -}}
+{{- else -}}
+  {{- include "lunar-mcpx-webapp.fullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+CronJob name-length validation.
+If the computed fullname exceeds 27 characters please supply cronJobBaseName (<= 27 chars).
+The 27-char limit exists because the longest CronJob suffix ("-migrate-rollback-execute",
+25 chars) plus the base name must fit within the Kubernetes 52-character CronJob name limit.
+Only CronJob names are affected; all other resources keep the standard fullname.
+*/}}
+{{- define "lunar-mcpx-webapp.validateNames" -}}
+{{- $fullname := include "lunar-mcpx-webapp.fullname" . -}}
+{{- $fullnameLen := int (len $fullname) -}}
+
+{{- if gt $fullnameLen 27 -}}
+  {{- if not .Values.cronJobBaseName -}}
+    {{- $msg := printf "\n\nVALIDATION ERROR:\nThe computed resource base name '%s' is %d characters long, exceeding the maximum of 27\ncharacters allowed for CronJob base names.\n\nCronJob resources append suffixes up to 25 characters (e.g. '-migrate-rollback-execute').\nCombined with the base name this would exceed Kubernetes' 52-character CronJob name limit.\n\nAll non-CronJob resources are unaffected. To fix this, add 'cronJobBaseName' to your\nvalues file (values.yaml or values-override) with a value up to 27 characters.\nThis value will be used exclusively for CronJob resource names.\n\nCurrent inputs:\n  Release name:      '%s' (%d chars)\n  nameOverride:      '%s' (%d chars)\n  fullnameOverride:  '%s' (%d chars)\n\nExample (add to your values file):\n  cronJobBaseName: \"my-short-name\"\n" $fullname $fullnameLen .Release.Name (len .Release.Name) (default "<not set>" .Values.nameOverride) (len (default "" .Values.nameOverride)) (default "<not set>" .Values.fullnameOverride) (len (default "" .Values.fullnameOverride)) -}}
+    {{- fail $msg -}}
+  {{- else if gt (int (len .Values.cronJobBaseName)) 27 -}}
+    {{- $msg := printf "\n\nVALIDATION ERROR:\ncronJobBaseName '%s' is %d characters long, exceeding the maximum of 27.\nPlease set cronJobBaseName to a value up to 27 characters.\n" .Values.cronJobBaseName (len .Values.cronJobBaseName) -}}
+    {{- fail $msg -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/lunar-mcpx-webapp/templates/lunar-jobs-cronjob.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-jobs-cronjob.yaml
@@ -3,9 +3,9 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ include "lunar-mcpx-webapp.fullname" . }}-db-ses-rtn
+  name: {{ include "lunar-mcpx-webapp.cronJobBaseName" . }}-db-ses-rtn
   labels:
-    service: {{ include "lunar-mcpx-webapp.fullname" . }}-db-ses-rtn
+    service: {{ include "lunar-mcpx-webapp.cronJobBaseName" . }}-db-ses-rtn
     {{- with .Values.global.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -24,7 +24,7 @@ spec:
       template:
         metadata:
           labels:
-            service: {{ include "lunar-mcpx-webapp.fullname" . }}-db-ses-rtn
+            service: {{ include "lunar-mcpx-webapp.cronJobBaseName" . }}-db-ses-rtn
             {{- include "lunar-mcpx-webapp.selectorLabels" . | nindent 12 }}
             {{- with .Values.global.labels }}
             {{- toYaml . | nindent 12 }}
@@ -100,9 +100,9 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ include "lunar-mcpx-webapp.fullname" . }}-hibernate-instances
+  name: {{ include "lunar-mcpx-webapp.cronJobBaseName" . }}-hibernate-instances
   labels:
-    service: {{ include "lunar-mcpx-webapp.fullname" . }}-hibernate-instances
+    service: {{ include "lunar-mcpx-webapp.cronJobBaseName" . }}-hibernate-instances
     {{- with .Values.global.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -121,7 +121,7 @@ spec:
       template:
         metadata:
           labels:
-            service: {{ include "lunar-mcpx-webapp.fullname" . }}-hibernate-instances
+            service: {{ include "lunar-mcpx-webapp.cronJobBaseName" . }}-hibernate-instances
             {{- include "lunar-mcpx-webapp.selectorLabels" . | nindent 12 }}
             {{- with .Values.global.labels }}
             {{- toYaml . | nindent 12 }}

--- a/charts/lunar-mcpx-webapp/templates/validation.yaml
+++ b/charts/lunar-mcpx-webapp/templates/validation.yaml
@@ -1,0 +1,1 @@
+{{- include "lunar-mcpx-webapp.validateNames" . -}}

--- a/charts/lunar-mcpx-webapp/values.schema.json
+++ b/charts/lunar-mcpx-webapp/values.schema.json
@@ -2,6 +2,12 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "properties": {
+    "cronJobBaseName": {
+      "type": "string",
+      "description": "Override base name used exclusively for CronJob resource names. Must be 27 characters or fewer. Use on helm upgrade when the computed fullname exceeds 27 characters.",
+      "default": "",
+      "maxLength": 27
+    },
     "global": {
       "type": "object",
       "properties": {

--- a/charts/lunar-mcpx-webapp/values.yaml
+++ b/charts/lunar-mcpx-webapp/values.yaml
@@ -3,7 +3,7 @@
 # fullnameOverride) exceeds 27 characters. Must be 27 characters or fewer.
 # Other resources are not affected by this value.
 cronJobBaseName: ""
-fullnameOverride: "a[wtrjg[0jaetrgwrgsaerstq3te]]"
+
 ## @section Global Section
 global:
   ## @param global.imagePullSecrets [default:\[lunar-private-mcpx-registry] Global Docker registry secret names as an array

--- a/charts/lunar-mcpx-webapp/values.yaml
+++ b/charts/lunar-mcpx-webapp/values.yaml
@@ -1,3 +1,9 @@
+# -- cronJobBaseName overrides the base name used exclusively for CronJob resource names.
+# Use this on `helm upgrade` when the computed fullname (from release name / nameOverride /
+# fullnameOverride) exceeds 27 characters. Must be 27 characters or fewer.
+# Other resources are not affected by this value.
+cronJobBaseName: ""
+fullnameOverride: "a[wtrjg[0jaetrgwrgsaerstq3te]]"
 ## @section Global Section
 global:
   ## @param global.imagePullSecrets [default:\[lunar-private-mcpx-registry] Global Docker registry secret names as an array


### PR DESCRIPTION
Added conjob name validation to fit within 52 chars limit for cronjobs. 