### PR TITLE
[mcpx-webapp] Admin Static OAuth support

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Read(//Users/eliavlavi/git/lunar-private/mcpx/packages/shared-model/src/config/**)"
+    ]
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "cSpell.words": [
     "datadoghq",
+    "githubcopilot",
     "mcpx",
     "Millis",
     "nindent",

--- a/charts/lunar-mcpx-webapp/README.md
+++ b/charts/lunar-mcpx-webapp/README.md
@@ -370,3 +370,60 @@ tools that honor `.netrc`. A single `.netrc` can contain credentials for multipl
 
 Make sure the referenced secrets already exist in the MCPX namespace before MCPX instances are
 created or restarted.
+
+### Static OAuth configuration
+
+Use `hub.staticOauth` to configure OAuth credentials that the Hub distributes to all connected
+MCPX instances. This is useful for MCP servers that require OAuth authentication (e.g. GitHub, Asana).
+
+Two auth methods are supported - depending on what the provider offers and supports:
+
+- **`device_flow`** — user authorizes via browser, only a client ID is needed.
+- **`client_credentials`** — traditional OAuth with client ID and secret.
+
+The `mapping` section maps domains to provider keys, and `providers` defines the credentials and
+endpoints for each provider. This allows you to match several related domains (e.g. `github.com`, `api.github.com`) to the same provider config.
+
+**Example: GitHub device flow**
+
+```yaml
+hub:
+  staticOauth:
+    mapping:
+      github.com: github
+      api.github.com: github
+      api.githubcopilot.com: github
+    providers:
+      github:
+        authMethod: device_flow
+        credentials:
+          clientId: "<from your app>"
+        scopes:
+          - repo
+        endpoints:
+          deviceAuthorizationUrl: https://github.com/login/device/code
+          tokenUrl: https://github.com/login/oauth/access_token
+          userVerificationUrl: https://github.com/login/device
+```
+
+**Example: Client credentials flow**
+
+```yaml
+hub:
+  staticOauth:
+    mapping:
+      api.example.com: my-provider
+    providers:
+      my-provider:
+        authMethod: client_credentials
+        credentials:
+          clientId: "..."
+          clientSecret: "..."
+        scopes:
+          - scope1
+          - scope2
+        tokenAuthMethod: client_secret_basic
+```
+
+Supported `tokenAuthMethod` values: `client_secret_basic`, `client_secret_post`,
+`client_secret_jwt`, `private_key_jwt`, `tls_client_auth`, `self_signed_tls_client_auth`.

--- a/charts/lunar-mcpx-webapp/templates/lunar-hub-deployment.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-hub-deployment.yaml
@@ -146,6 +146,10 @@ spec:
           {{- if .Values.hub.extraEnvVars }}
           {{- include "lunar-mcpx-webapp.tplvalues.render" (dict "value" .Values.hub.extraEnvVars "context" $) | nindent 12 }}
           {{- end }}
+          {{- if .Values.hub.staticOauth | default dict | keys }}
+            - name: MCPX_STATIC_OAUTH_CONFIG
+              value: {{ .Values.hub.staticOauth | toJson | quote }}
+          {{- end }}
 
           startupProbe:
             successThreshold: 1

--- a/charts/lunar-mcpx-webapp/tests/hub_static_oauth_test.yaml
+++ b/charts/lunar-mcpx-webapp/tests/hub_static_oauth_test.yaml
@@ -22,15 +22,8 @@ tests:
           any: true
 
   - it: should render MCPX_STATIC_OAUTH_CONFIG with correct JSON when staticOauth is configured
-    set:
-      hub.staticOauth.mapping.github\.com: github
-      hub.staticOauth.mapping.api\.github\.com: github
-      hub.staticOauth.providers.github.authMethod: device_flow
-      hub.staticOauth.providers.github.credentials.clientId: "test-client-id"
-      hub.staticOauth.providers.github.scopes[0]: repo
-      hub.staticOauth.providers.github.endpoints.deviceAuthorizationUrl: "https://github.com/login/device/code"
-      hub.staticOauth.providers.github.endpoints.tokenUrl: "https://github.com/login/oauth/access_token"
-      hub.staticOauth.providers.github.endpoints.userVerificationUrl: "https://github.com/login/device"
+    values:
+      - hub_static_oauth_test_values.yaml
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env

--- a/charts/lunar-mcpx-webapp/tests/hub_static_oauth_test.yaml
+++ b/charts/lunar-mcpx-webapp/tests/hub_static_oauth_test.yaml
@@ -1,0 +1,39 @@
+suite: Hub static OAuth
+templates:
+  - templates/lunar-hub-deployment.yaml
+
+tests:
+  - it: should not render MCPX_STATIC_OAUTH_CONFIG by default
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCPX_STATIC_OAUTH_CONFIG
+          any: true
+
+  - it: should not render MCPX_STATIC_OAUTH_CONFIG when staticOauth is empty
+    set:
+      hub.staticOauth: {}
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCPX_STATIC_OAUTH_CONFIG
+          any: true
+
+  - it: should render MCPX_STATIC_OAUTH_CONFIG with correct JSON when staticOauth is configured
+    set:
+      hub.staticOauth.mapping.github\.com: github
+      hub.staticOauth.mapping.api\.github\.com: github
+      hub.staticOauth.providers.github.authMethod: device_flow
+      hub.staticOauth.providers.github.credentials.clientId: "test-client-id"
+      hub.staticOauth.providers.github.scopes[0]: repo
+      hub.staticOauth.providers.github.endpoints.deviceAuthorizationUrl: "https://github.com/login/device/code"
+      hub.staticOauth.providers.github.endpoints.tokenUrl: "https://github.com/login/oauth/access_token"
+      hub.staticOauth.providers.github.endpoints.userVerificationUrl: "https://github.com/login/device"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCPX_STATIC_OAUTH_CONFIG
+            value: '{"mapping":{"api.github.com":"github","github.com":"github"},"providers":{"github":{"authMethod":"device_flow","credentials":{"clientId":"test-client-id"},"endpoints":{"deviceAuthorizationUrl":"https://github.com/login/device/code","tokenUrl":"https://github.com/login/oauth/access_token","userVerificationUrl":"https://github.com/login/device"},"scopes":["repo"]}}}'

--- a/charts/lunar-mcpx-webapp/tests/hub_static_oauth_test_values.yaml
+++ b/charts/lunar-mcpx-webapp/tests/hub_static_oauth_test_values.yaml
@@ -1,0 +1,16 @@
+hub:
+  staticOauth:
+    mapping:
+      github.com: github
+      api.github.com: github
+    providers:
+      github:
+        authMethod: device_flow
+        credentials:
+          clientId: "test-client-id"
+        scopes:
+          - repo
+        endpoints:
+          deviceAuthorizationUrl: "https://github.com/login/device/code"
+          tokenUrl: "https://github.com/login/oauth/access_token"
+          userVerificationUrl: "https://github.com/login/device"

--- a/charts/lunar-mcpx-webapp/values.schema.json
+++ b/charts/lunar-mcpx-webapp/values.schema.json
@@ -76,6 +76,10 @@
               }
             }
           }
+        },
+        "staticOauth": {
+          "type": "object",
+          "description": "Static OAuth configuration for MCP server authentication. Maps domains to OAuth providers with credentials."
         }
       }
     },

--- a/charts/lunar-mcpx-webapp/values.yaml
+++ b/charts/lunar-mcpx-webapp/values.yaml
@@ -179,6 +179,44 @@ hub:
   #   - secret_2
   extraEnvFromSecrets: []
 
+  # Static OAuth configuration for MCP server authentication.
+  # Maps domains to OAuth providers with credentials that are
+  # distributed to all connected mcpx instances.
+  #
+  # Example: Device flow (e.g. GitHub)
+  # staticOauth:
+  #   mapping:
+  #     github.com: github
+  #     api.github.com: github
+  #     api.githubcopilot.com: github
+  #   providers:
+  #     github:
+  #       authMethod: device_flow
+  #       credentials:
+  #         clientId: "<from your app>"
+  #       scopes:
+  #         - repo
+  #       endpoints:
+  #         deviceAuthorizationUrl: https://github.com/login/device/code
+  #         tokenUrl: https://github.com/login/oauth/access_token
+  #         userVerificationUrl: https://github.com/login/device
+  #
+  # Example: Client credentials flow
+  # staticOauth:
+  #   mapping:
+  #     api.example.com: my-provider
+  #   providers:
+  #     my-provider:
+  #       authMethod: client_credentials
+  #       credentials:
+  #         clientId: "..."
+  #         clientSecret: "..."
+  #       scopes:
+  #         - scope1
+  #         - scope2
+  #       tokenAuthMethod: client_secret_basic
+  staticOauth: {}
+
   # Labels for all application related resources
   # labels:
   #   label_1: value_1


### PR DESCRIPTION
This PR adds `hub.staticOauth` — a chart-level config block that lets admin/ops define OAuth credentials for MCP servers once, and have the Hub distribute them to all connected MCPX instances via the `MCPX_STATIC_OAUTH_CONFIG` env var.

Two auth methods supported:
- **`device_flow`** — user authorizes via browser, only a client ID needed (e.g. GitHub)
- **`client_credentials`** — standard OAuth with client ID + secret

The `mapping` section maps domains to provider keys so you can point multiple related domains (e.g. `github.com`, `api.github.com`, `api.githubcopilot.com`) at the same provider config.

The env var only gets injected when `staticOauth` is non-empty — empty map (`{}`) or unset = no env var.

Also includes:
- Helm test for the three cases (default/empty/configured)
- README docs with full examples for both flows
- JSON schema entry for the new field
