### PR TITLE
[RND-253] lunar-mcpx-webapp: expose mcpxNodeSelector + mcpxTolerations for MCPX instance pods

### DIFF
--- a/charts/lunar-mcpx-webapp/templates/lunar-hive-controller-deployment.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-hive-controller-deployment.yaml
@@ -131,6 +131,16 @@ spec:
             - name: MCPX_RUNTIME_AUTH_JSON
               value: {{ $runtimeAuth | toJson | quote }}
           {{- end }}
+          {{- $mcpxNodeSelector := .Values.controller.mcpxNodeSelector | default dict }}
+          {{- if $mcpxNodeSelector }}
+            - name: MCPX_NODE_SELECTOR
+              value: {{ $mcpxNodeSelector | toJson | quote }}
+          {{- end }}
+          {{- $mcpxTolerations := .Values.controller.mcpxTolerations | default list }}
+          {{- if $mcpxTolerations }}
+            - name: MCPX_TOLERATIONS
+              value: {{ $mcpxTolerations | toJson | quote }}
+          {{- end }}
           {{- if .Values.global.extraEnvVars }}
           {{- include "lunar-mcpx-webapp.tplvalues.render" (dict "value" .Values.global.extraEnvVars "context" $) | nindent 12 }}
           {{- end }}

--- a/charts/lunar-mcpx-webapp/values.yaml
+++ b/charts/lunar-mcpx-webapp/values.yaml
@@ -392,6 +392,23 @@ controller:
     # -- netrcSecret Name of a secret containing a `.netrc` key exposed via NETRC.
     netrcSecret: ""
 
+  # -- mcpxNodeSelector NodeSelector applied to every MCPX instance pod created by the controller.
+  # Useful to constrain MCPX workloads to dedicated node pools (e.g. GPU nodes, spot nodes).
+  # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+  # mcpxNodeSelector:
+  #   cloud.google.com/gke-nodepool: mcpx-pool
+  mcpxNodeSelector: {}
+
+  # -- mcpxTolerations Tolerations applied to every MCPX instance pod created by the controller.
+  # Must match taints on the target nodes when mcpxNodeSelector targets tainted node pools.
+  # https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+  # mcpxTolerations:
+  #   - key: "dedicated"
+  #     operator: "Equal"
+  #     value: "mcpx"
+  #     effect: "NoSchedule"
+  mcpxTolerations: []
+
   # -- mcpxCRD configuration for CRD schema version checks
   mcpxCRD:
     # -- Enable strict schema version checking


### PR DESCRIPTION
Adds `controller.mcpxNodeSelector` and `controller.mcpxTolerations` to the
`lunar-mcpx-webapp` chart and wires them as environment variables into the
hive-controller container.

## Changes

**`values.yaml`**
- Added `controller.mcpxNodeSelector: {}` — node selector applied to every
  MCPX instance pod created by the controller
- Added `controller.mcpxTolerations: []` — tolerations applied to every
  MCPX instance pod created by the controller
- Both follow the `mcpxRuntimeAuth` naming convention and include inline docs
  with usage examples

**`templates/lunar-hive-controller-deployment.yaml`**
- JSON-encodes and injects `MCPX_NODE_SELECTOR` and `MCPX_TOLERATIONS` as
  env vars on the controller container when the values are non-empty,
  mirroring the existing `mcpxRuntimeAuth` block pattern

## Usage

```yaml
controller:
  mcpxNodeSelector:
    cloud.google.com/gke-nodepool: mcpx-pool

  mcpxTolerations:
    - key: "dedicated"
      operator: "Equal"
      value: "mcpx"
      effect: "NoSchedule"
