### PR TITLE
[mcpx-webapp] ID aware mcp server wiring

### DIFF
--- a/charts/lunar-mcpx-webapp/templates/_helpers.tpl
+++ b/charts/lunar-mcpx-webapp/templates/_helpers.tpl
@@ -70,6 +70,20 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Default in-cluster JWKS URI for the auth-bff service.
+*/}}
+{{- define "lunar-mcpx-webapp.authJwksUri" -}}
+http://{{ include "lunar-mcpx-webapp.fullname" . }}-auth/.well-known/jwks.json
+{{- end }}
+
+{{/*
+JWT audience for tokens minted by auth-bff.
+*/}}
+{{- define "lunar-mcpx-webapp.jwtAudience" -}}
+mcpx
+{{- end }}
+
+{{/*
 Renders a value that contains template.
 Usage:
 {{ include "lunar-mcpx-webapp.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $) }}

--- a/charts/lunar-mcpx-webapp/templates/lunar-auth-bff-deployment.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-auth-bff-deployment.yaml
@@ -149,6 +149,8 @@ spec:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: "/var/secrets/google/credentials.json"
             {{- end }}
+            - name: JWT_AUDIENCE
+              value: {{ include "lunar-mcpx-webapp.jwtAudience" . | quote }}
           {{- if .Values.ingress.enabled }}
             - name: JWT_ISSUER
               value: "https://{{ first .Values.ingress.domains.auth }}"

--- a/charts/lunar-mcpx-webapp/templates/lunar-hive-controller-deployment.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-hive-controller-deployment.yaml
@@ -129,7 +129,13 @@ spec:
               value: "https://{{ first .Values.ingress.domains.router }}"
             - name: UI_DOMAIN
               value: "https://{{ first .Values.ingress.domains.ui }}"
+            - name: MCPX_AUTH_JWKS_URI
+              value: "https://{{ first .Values.ingress.domains.auth }}/.well-known/jwks.json"
+            - name: MCPX_AUTH_JWT_ISSUER
+              value: "https://{{ first .Values.ingress.domains.auth }}"
           {{- end }}
+            - name: MCPX_AUTH_JWT_AUDIENCE
+              value: {{ include "lunar-mcpx-webapp.jwtAudience" . | quote }}
           {{- $runtimeAuth := .Values.controller.mcpxRuntimeAuth | default dict }}
           {{- if or $runtimeAuth.dockerConfigSecret $runtimeAuth.npmrcSecret $runtimeAuth.uvConfigSecret $runtimeAuth.netrcSecret }}
             - name: MCPX_RUNTIME_AUTH_JSON

--- a/charts/lunar-mcpx-webapp/templates/lunar-hive-router-deployment.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-hive-router-deployment.yaml
@@ -98,9 +98,8 @@ spec:
               value: "https://{{ first .Values.ingress.domains.ui }}"
             - name: WEBSERVER_URL
               value: "http://{{ include "lunar-mcpx-webapp.fullname" . }}-webserver:4000"
-            {{- $defaultOidcJwksUri := printf "http://%s-auth/.well-known/jwks.json" (include "lunar-mcpx-webapp.fullname" .) }}
             - name: OIDC_JWKS_URI
-              value: {{ .Values.router.oidcJwksUri | default $defaultOidcJwksUri | quote }}
+              value: {{ .Values.router.oidcJwksUri | default (include "lunar-mcpx-webapp.authJwksUri" .) | quote }}
           {{- if .Values.ingress.enabled }}
             - name: AUTH_BFF_URL
               value: "https://{{ first .Values.ingress.domains.auth }}"

--- a/charts/lunar-mcpx-webapp/tests/mcpx_auth_env_test.yaml
+++ b/charts/lunar-mcpx-webapp/tests/mcpx_auth_env_test.yaml
@@ -1,0 +1,95 @@
+suite: MCPX auth env vars
+templates:
+  - templates/lunar-hive-controller-deployment.yaml
+  - templates/lunar-hive-router-deployment.yaml
+  - templates/lunar-auth-bff-deployment.yaml
+
+tests:
+  # --- controller ---
+  # Uses the external auth domain (not in-cluster) because Docker-based
+  # hosted servers can't resolve cluster-internal DNS.
+  - it: controller sets MCPX_AUTH_JWKS_URI to external auth domain
+    template: templates/lunar-hive-controller-deployment.yaml
+    release:
+      name: my-release
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCPX_AUTH_JWKS_URI
+            value: "https://mcpx-auth.example.com/.well-known/jwks.json"
+
+  - it: controller sets MCPX_AUTH_JWT_ISSUER from auth ingress domain
+    template: templates/lunar-hive-controller-deployment.yaml
+    release:
+      name: my-release
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCPX_AUTH_JWT_ISSUER
+            value: "https://mcpx-auth.example.com"
+
+  - it: controller sets MCPX_AUTH_JWT_AUDIENCE to shared jwt audience
+    template: templates/lunar-hive-controller-deployment.yaml
+    release:
+      name: my-release
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCPX_AUTH_JWT_AUDIENCE
+            value: "mcpx"
+
+  - it: controller omits MCPX_AUTH_JWKS_URI and MCPX_AUTH_JWT_ISSUER when ingress is disabled
+    template: templates/lunar-hive-controller-deployment.yaml
+    release:
+      name: my-release
+    set:
+      ingress.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCPX_AUTH_JWKS_URI
+          any: true
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCPX_AUTH_JWT_ISSUER
+          any: true
+
+  # --- router (contrast: uses in-cluster URL, not external) ---
+  - it: router sets OIDC_JWKS_URI to in-cluster auth-bff
+    template: templates/lunar-hive-router-deployment.yaml
+    release:
+      name: my-release
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OIDC_JWKS_URI
+            value: "http://my-release-lunar-mcpx-webapp-auth/.well-known/jwks.json"
+
+  # --- auth-bff ---
+  - it: auth-bff sets JWT_AUDIENCE to shared jwt audience
+    template: templates/lunar-auth-bff-deployment.yaml
+    release:
+      name: my-release
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: JWT_AUDIENCE
+            value: "mcpx"
+
+  - it: auth-bff and controller share the same audience value
+    template: templates/lunar-auth-bff-deployment.yaml
+    release:
+      name: my-release
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: JWT_AUDIENCE
+            value: "mcpx"


### PR DESCRIPTION
This PR adds the helm wiring so hosted MCP servers can verify user identity tokens without manual configuration.

The hive-controller deployment now passes three new env vars (`MCPX_AUTH_JWKS_URI`, `MCPX_AUTH_JWT_ISSUER`, `MCPX_AUTH_JWT_AUDIENCE`) which flow down to mcpx pods and into child stdio processes. All values derive automatically from existing chart config (auth ingress domain, release name) — no new values.yaml fields needed.

- **JWKS URI uses the external auth domain** (not in-cluster) because Docker-based hosted servers run in their own network namespace and can't resolve cluster-internal DNS
- **JWT audience (`mcpx`)** is now single-sourced via a shared helper, used by both auth-bff (`JWT_AUDIENCE`) and controller (`MCPX_AUTH_JWT_AUDIENCE`) — previously `OIDC_AUDIENCE` only lived in the user-created secret
- Refactored the router's `OIDC_JWKS_URI` to use the same `authJwksUri` helper (in-cluster default, since the router runs inside the cluster)

Companion to TheLunarCompany/lunar-private#2834