### PR TITLE
router: expose internal port 4000 for in-cluster calls

### DIFF
--- a/charts/lunar-mcpx-webapp/templates/lunar-hive-router-deployment.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-hive-router-deployment.yaml
@@ -49,6 +49,8 @@ spec:
           ports:
             - containerPort: 8080
               name: router
+            - containerPort: {{ .Values.router.internalPort | default 4000 }}
+              name: internal
           {{- if or (.Values.global.manageResources.limits) (.Values.global.manageResources.requests) }}
           resources:
             {{- if .Values.global.manageResources.limits }}
@@ -94,6 +96,8 @@ spec:
                   fieldPath: metadata.namespace
             - name: PORT
               value: "8080"
+            - name: INTERNAL_PORT
+              value: "{{ .Values.router.internalPort | default 4000 }}"
             - name: CORS_ORIGINS
               value: "https://{{ first .Values.ingress.domains.ui }}"
             - name: WEBSERVER_URL

--- a/charts/lunar-mcpx-webapp/templates/lunar-hive-router-service.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-hive-router-service.yaml
@@ -25,6 +25,9 @@ spec:
     - name: router80
       port: 80
       targetPort: 8080
+    - name: internal
+      port: {{ .Values.router.internalPort | default 4000 }}
+      targetPort: internal
   sessionAffinity: ClientIP
   type: ClusterIP
   selector:

--- a/charts/lunar-mcpx-webapp/values.yaml
+++ b/charts/lunar-mcpx-webapp/values.yaml
@@ -516,6 +516,10 @@ router:
   # If empty, defaults to the in-cluster auth service URL.
   oidcJwksUri: ""
 
+  # -- Internal HTTP port the router serves for in-cluster calls from other pods.
+  # Exposed on the router Service (ClusterIP) but never via Ingress.
+  internalPort: 4000
+
   # -- extraEnvVars An array to add extra env vars
   # e.g:
   # extraEnvVars:


### PR DESCRIPTION
Adds a second containerPort and INTERNAL_PORT env on the router Deployment, plus a matching ClusterIP Service port, all driven by the new router.internalPort value (default 4000). Internal only, not added to ingress.

Accompanies https://github.com/TheLunarCompany/lunar-private/pull/3077