### PR TITLE
[mcpx-webapp] CH disk usage fix

### DIFF
--- a/charts/lunar-mcpx-webapp/README.tpl.md
+++ b/charts/lunar-mcpx-webapp/README.tpl.md
@@ -290,6 +290,24 @@ kubectl create job catalog-derived-host-backfill-$(date +%s) \
 
 > **Note:** This job is idempotent — it only updates items where `derivedHost` is null. Stdio catalog items are skipped.
 
+### ClickHouse System-Log Pruning
+
+When `clickhouse.enabled` is set, `clickhouse.systemLogConfig` disables ClickHouse's internal system-log tables (`text_log`, `trace_log`, `metric_log`, `asynchronous_metric_log`) going forward — they grow with server uptime and can fill the data volume. Historical rows written before that may still be sitting on the volume; they have no use, so the chart includes two **suspended CronJobs** to drop them. Running these is optional (not mandatory) and, like the other admin jobs, they never run automatically.
+
+| CronJob | Purpose |
+|:--------|:--------|
+| `<release>-prune-ch-logs-dry` | Reports which tables would be dropped and how many bytes would be freed (no changes) |
+| `<release>-prune-ch-logs-execute` | **Drops** the noisy system-log tables |
+
+**Run a dry run, then execute:**
+```bash
+kubectl create job prune-ch-logs-dry-$(date +%s) \
+  --from=cronjob/<release>-prune-ch-logs-dry -n <namespace>
+
+kubectl create job prune-ch-logs-execute-$(date +%s) \
+  --from=cronjob/<release>-prune-ch-logs-execute -n <namespace>
+```
+
 ### Hibernation Cron Schedule
 
 Use `hibernation.cronSchedule` to control when the `hibernate-instances` CronJob runs.

--- a/charts/lunar-mcpx-webapp/templates/_admin-job-helpers.tpl
+++ b/charts/lunar-mcpx-webapp/templates/_admin-job-helpers.tpl
@@ -66,6 +66,10 @@ spec:
               envFrom:
                 - secretRef:
                     name: {{ include "lunar-mcpx-webapp.fullname" .root }}-embedded
+              {{- if and .clickhouse (.root.Values.clickhouse.enabled | default false) }}
+                - secretRef:
+                    name: {{ .root.Values.clickhouse.credentialsSecret }}
+              {{- end }}
               {{- with .root.Values.global.extraEnvFromSecrets }}
               {{- range . }}
                 - secretRef:
@@ -79,6 +83,10 @@ spec:
               {{- end }}
               {{- end }}
               env:
+              {{- if and .clickhouse (.root.Values.clickhouse.enabled | default false) }}
+                - name: CLICKHOUSE_URL
+                  value: "{{ include "lunar-mcpx-webapp.clickhouseUrl" .root }}"
+              {{- end }}
               {{- range .extraEnv }}
               {{- if .value }}
                 - name: {{ .name }}

--- a/charts/lunar-mcpx-webapp/templates/clickhouse-configmap.yaml
+++ b/charts/lunar-mcpx-webapp/templates/clickhouse-configmap.yaml
@@ -1,0 +1,15 @@
+{{- if and (.Values.clickhouse.enabled | default false) .Values.clickhouse.systemLogConfig }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "lunar-mcpx-webapp.fullname" . }}-clickhouse-config
+  labels:
+    name: {{ include "lunar-mcpx-webapp.fullname" . }}-clickhouse
+    app: {{ include "lunar-mcpx-webapp.fullname" . }}-clickhouse
+    {{- with .Values.global.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+data:
+  z-lunar-system-logs.xml: |
+    {{- .Values.clickhouse.systemLogConfig | nindent 4 }}
+{{- end }}

--- a/charts/lunar-mcpx-webapp/templates/clickhouse-statefulset.yaml
+++ b/charts/lunar-mcpx-webapp/templates/clickhouse-statefulset.yaml
@@ -70,6 +70,11 @@ spec:
             - name: data
               mountPath: /var/lib/clickhouse
             {{- end }}
+            {{- if .Values.clickhouse.systemLogConfig }}
+            - name: system-log-config
+              mountPath: /etc/clickhouse-server/config.d/z-lunar-system-logs.xml
+              subPath: z-lunar-system-logs.xml
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /ping
@@ -84,6 +89,12 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
+      {{- if .Values.clickhouse.systemLogConfig }}
+      volumes:
+        - name: system-log-config
+          configMap:
+            name: {{ include "lunar-mcpx-webapp.fullname" . }}-clickhouse-config
+      {{- end }}
       {{- with .Values.clickhouse.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/lunar-mcpx-webapp/templates/lunar-admin-prune-clickhouse-system-logs-dry-cronjob.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-admin-prune-clickhouse-system-logs-dry-cronjob.yaml
@@ -2,7 +2,7 @@
 ---
 {{- include "lunar-mcpx-webapp.adminCronJob" (dict
   "root" .
-  "jobName" "prune-clickhouse-system-logs-dry"
+  "jobName" "prune-ch-logs-dry"
   "command" (list "node" "dist/index.js" "prune-clickhouse-system-logs")
   "clickhouse" true
   "extraEnv" (list

--- a/charts/lunar-mcpx-webapp/templates/lunar-admin-prune-clickhouse-system-logs-dry-cronjob.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-admin-prune-clickhouse-system-logs-dry-cronjob.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.clickhouse.enabled | default false }}
+---
+{{- include "lunar-mcpx-webapp.adminCronJob" (dict
+  "root" .
+  "jobName" "prune-clickhouse-system-logs-dry"
+  "command" (list "node" "dist/index.js" "prune-clickhouse-system-logs")
+  "clickhouse" true
+  "extraEnv" (list
+    (dict "name" "CLICKHOUSE_PRUNE_DRY_RUN" "value" "true")
+  )
+) }}
+{{- end }}

--- a/charts/lunar-mcpx-webapp/templates/lunar-admin-prune-clickhouse-system-logs-execute-cronjob.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-admin-prune-clickhouse-system-logs-execute-cronjob.yaml
@@ -2,7 +2,7 @@
 ---
 {{- include "lunar-mcpx-webapp.adminCronJob" (dict
   "root" .
-  "jobName" "prune-clickhouse-system-logs-execute"
+  "jobName" "prune-ch-logs-execute"
   "command" (list "node" "dist/index.js" "prune-clickhouse-system-logs")
   "clickhouse" true
   "extraEnv" (list

--- a/charts/lunar-mcpx-webapp/templates/lunar-admin-prune-clickhouse-system-logs-execute-cronjob.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-admin-prune-clickhouse-system-logs-execute-cronjob.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.clickhouse.enabled | default false }}
+---
+{{- include "lunar-mcpx-webapp.adminCronJob" (dict
+  "root" .
+  "jobName" "prune-clickhouse-system-logs-execute"
+  "command" (list "node" "dist/index.js" "prune-clickhouse-system-logs")
+  "clickhouse" true
+  "extraEnv" (list
+    (dict "name" "CLICKHOUSE_PRUNE_DRY_RUN" "value" "false")
+  )
+) }}
+{{- end }}

--- a/charts/lunar-mcpx-webapp/values.yaml
+++ b/charts/lunar-mcpx-webapp/values.yaml
@@ -859,6 +859,19 @@ clickhouse:
       - ReadWriteOnce
     storageClassName: ""
     size: 10Gi
+  # -- Caps ClickHouse's internal system-log tables, which otherwise grow with
+  # server uptime (not with usage) and can fill the data volume. text_log mirrors
+  # the server log you already ship to stdout/Loki, and the metric/trace logs
+  # overlap the Prometheus monitor, so they're disabled by default. Mounted into
+  # /etc/clickhouse-server/config.d/. Set to "" to keep ClickHouse defaults, or
+  # replace with your own XML to keep some logs (e.g. a short TTL instead).
+  systemLogConfig: |
+    <clickhouse>
+        <text_log remove="1"/>
+        <trace_log remove="1"/>
+        <metric_log remove="1"/>
+        <asynchronous_metric_log remove="1"/>
+    </clickhouse>
   # -- Resource defaults: CH docs recommend 4 CPU / 8Gi RAM as practical minimum.
   # Limits set to 2x requests for burst headroom.
   resources:


### PR DESCRIPTION
This PR caps ClickHouse's internal system-log tables, which grow with server uptime (not usage) and were filling the data volume.

- `clickhouse.systemLogConfig`: a config.d XML that disables `text_log`, `trace_log`, `metric_log`, and `asynchronous_metric_log` going forward. Mounted into `/etc/clickhouse-server/config.d/` via a new ConfigMap + statefulset volume. Set to `""` to keep CH defaults, or override with your own XML (e.g. a short TTL).
- Two suspended admin CronJobs (`<release>-prune-ch-logs-dry` / `-execute`) that run the new jobs-image command to drop the rows already on disk. Manual-trigger only, like the other admin jobs. Optional — the config alone stops new growth.
- Admin-job helper now injects `CLICKHOUSE_URL` + the credentials secret for clickhouse jobs.

Pairs with lunar-private [#3090](https://github.com/TheLunarCompany/lunar-private/pull/3090) (the prune job itself). Validated on a sandbox: freed ~1.74 GiB and the tables stay gone.