### PR TITLE
Fix admin UI Next.js image cache on read-only root filesystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@
 *.tmp.yaml
 settings.local.json
 charts/**/test.yaml
+
+.idea

--- a/charts/lunar-mcpx-webapp/templates/lunar-admin-ui-deployment.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-admin-ui-deployment.yaml
@@ -43,6 +43,11 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if not (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: OnRootMismatch
+      {{- end }}
       {{- with concat (.Values.global.extraInitContainers | default (list)) (.Values.admin.extraInitContainers | default (list)) }}
       initContainers:
         {{- toYaml . | nindent 8 }}
@@ -72,8 +77,8 @@ spec:
             runAsNonRoot: true
             allowPrivilegeEscalation: false
             {{- if not (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
-            runAsUser: 1000
-            runAsGroup: 1000
+            runAsUser: 1001
+            runAsGroup: 1001
             {{- end }}
           envFrom:
             - secretRef:
@@ -142,8 +147,12 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 10
 
-          {{- with .Values.global.caCerts }}
           volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: next-cache
+              mountPath: /app/packages/admin-ui/.next/cache
+          {{- with .Values.global.caCerts }}
           {{- with .secretName }}
             - name: {{ . }}
               mountPath: "/usr/local/share/ca-certificates/"
@@ -155,6 +164,8 @@ spec:
         {{- end }}
       volumes:
         - name: tmp
+          emptyDir: {}
+        - name: next-cache
           emptyDir: {}
         {{- with .Values.global.caCerts }}
         {{- with .secretName }}

--- a/charts/lunar-mcpx-webapp/tests/admin_deployment_test.yaml
+++ b/charts/lunar-mcpx-webapp/tests/admin_deployment_test.yaml
@@ -1,0 +1,66 @@
+suite: Admin deployment
+templates:
+  - templates/lunar-admin-ui-deployment.yaml
+
+tests:
+  - it: should mount writable runtime directories with a read-only root filesystem
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: tmp
+            mountPath: /tmp
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: next-cache
+            mountPath: /app/packages/admin-ui/.next/cache
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tmp
+            emptyDir: {}
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: next-cache
+            emptyDir: {}
+
+  - it: should run as the admin image user
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1001
+      - equal:
+          path: spec.template.spec.securityContext.fsGroupChangePolicy
+          value: OnRootMismatch
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 1001
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 1001
+
+  - it: should still render CA mounts with runtime directory mounts
+    set:
+      global.caCerts.secretName: ca-example-com-1
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: tmp
+            mountPath: /tmp
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: next-cache
+            mountPath: /app/packages/admin-ui/.next/cache
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: ca-example-com-1
+            mountPath: /usr/local/share/ca-certificates/
+            readOnly: true


### PR DESCRIPTION
## Problem

https://app.clickup.com/t/90181236044/RND-798

The MCPX admin UI runs `next start` in production with `readOnlyRootFilesystem: true`. Next.js image optimization writes optimized images to disk at runtime under the app's build cache, specifically `<distDir>/cache/images` (`.next/cache/images` with the default `distDir`).

Because the admin deployment did not mount a writable directory at `/app/packages/admin-ui/.next/cache`, Next.js failed when it tried to create `/app/packages/admin-ui/.next/cache/images`:

```text
ENOENT: no such file or directory, mkdir '/app/packages/admin-ui/.next/cache/images'
```

There was also a UID mismatch: the admin image creates the `mcpx-admin` user as UID/GID `1001`, while the chart forced UID/GID `1000` for the container.

## Fix

- Mount an `emptyDir` volume at `/app/packages/admin-ui/.next/cache` so Next.js has writable runtime cache storage while keeping `readOnlyRootFilesystem: true`.
- Mount an `emptyDir` volume at `/tmp` for runtime temp writes.
- Align the admin pod/container security context with the image user by using UID/GID `1001` and `fsGroup: 1001`.
- Preserve the OpenShift behavior by keeping fixed UID/GID settings behind the existing OpenShift capability guard.
- Add Helm unittest coverage for the runtime mounts, security context, and CA certificate mount compatibility.

## Relevant Next.js documentation

- [`next start`](https://nextjs.org/docs/pages/api-reference/cli/next#next-start-options): runs the app in production mode after `next build`.
- [Self-hosting Image Optimization](https://nextjs.org/docs/app/guides/self-hosting#image-optimization): image optimization works with `next start`, and images are optimized at runtime rather than during build.
- [`next/image` disk cache](https://nextjs.org/docs/app/api-reference/components/image#maximumdiskcachesize): the default image optimizer writes optimized images to disk for subsequent requests.
- [Image caching behavior](https://nextjs.org/docs/pages/api-reference/components/image-legacy#caching-behavior): optimized images are stored in `<distDir>/cache/images`.
- [Self-hosted caching on Kubernetes](https://nextjs.org/docs/14/app/building-your-application/deploying#configuring-caching): generated cache assets are stored in memory and on disk by default, and each Kubernetes pod has its own cache unless configured otherwise.

## Verification

- `helm unittest ./charts/lunar-mcpx-webapp`