### PR TITLE
[mcpx-webapp] Add idle hibernation toggle (hibernation.idleMinutes)

### DIFF
--- a/charts/lunar-mcpx-webapp/README.tpl.md
+++ b/charts/lunar-mcpx-webapp/README.tpl.md
@@ -328,9 +328,13 @@ kubectl create job drain-swaps-execute-$(date +%s) \
 
 > **Note:** Once you upgrade the MCPX pods in the system, any affected setup will be the correct one.
 
-### Hibernation Cron Schedule
+### Hibernation
 
-Use `hibernation.cronSchedule` to control when the `hibernate-instances` CronJob runs.
+Two independent ways to hibernate idle MCPX instances. Either one (or both) turns
+`HIBERNATION_ENABLED` on for the webserver, and they can run together.
+
+**Scheduled (CronJob).** `hibernation.cronSchedule` controls when the `hibernate-instances`
+CronJob runs.
 
 - Build/verify cron expressions with [crontab.guru](https://crontab.guru/).
 - Keep it empty to disable the CronJob:
@@ -347,6 +351,23 @@ Use `hibernation.cronSchedule` to control when the `hibernate-instances` CronJob
   ```yaml
   hibernation:
     cronSchedule: "*/5 * * * *"
+  ```
+
+**Idle (signal-based).** `hibernation.idleMinutes` hibernates any instance with no real usage
+for that many minutes. The webserver runs an in-process reconciler; no CronJob involved.
+
+- `0` disables it (default). Apart from `0`, the effective minimum is `3`: values of `1` or
+  `2` are clamped up to `3`.
+- Idle-only (no schedule):
+  ```yaml
+  hibernation:
+    idleMinutes: 30
+  ```
+- Both together (scheduled sweep plus idle reconciler):
+  ```yaml
+  hibernation:
+    cronSchedule: "0 22 * * *"
+    idleMinutes: 30
   ```
 
 ### ClickHouse (Event Store Analytics)

--- a/charts/lunar-mcpx-webapp/templates/lunar-webserver-deployment.yaml
+++ b/charts/lunar-mcpx-webapp/templates/lunar-webserver-deployment.yaml
@@ -186,9 +186,13 @@ spec:
             - name: ROUTER_INTERNAL_URL
               value: "http://{{ include "lunar-mcpx-webapp.fullname" . }}-router:{{ .Values.router.internalPort | default 4000 }}"
             {{- end }}
-            {{- if .Values.hibernation.cronSchedule }}
+            {{- if or .Values.hibernation.cronSchedule (gt (int .Values.hibernation.idleMinutes) 0) }}
             - name: HIBERNATION_ENABLED
               value: "true"
+            {{- end }}
+            {{- if gt (int .Values.hibernation.idleMinutes) 0 }}
+            - name: HIBERNATION_IDLE_MINUTES
+              value: {{ .Values.hibernation.idleMinutes | quote }}
             {{- end }}
             - name: WEBAPP_DEPLOYMENT_PREFIX
               value: {{ include "lunar-mcpx-webapp.fullname" . | quote }}

--- a/charts/lunar-mcpx-webapp/values.schema.json
+++ b/charts/lunar-mcpx-webapp/values.schema.json
@@ -335,6 +335,12 @@
           "type": "string",
           "description": "Cron schedule for the scheduled hibernation job. Leave empty to disable the CronJob.",
           "default": ""
+        },
+        "idleMinutes": {
+          "type": "integer",
+          "description": "Idle window in minutes. Instances with no real usage for this long are hibernated. 0 disables idle hibernation; any value > 0 also turns HIBERNATION_ENABLED on. Apart from 0, the effective minimum is 3: values of 1 or 2 are clamped up to 3.",
+          "default": 0,
+          "minimum": 0
         }
       }
     },

--- a/charts/lunar-mcpx-webapp/values.yaml
+++ b/charts/lunar-mcpx-webapp/values.yaml
@@ -1012,6 +1012,10 @@ hibernation:
   # Cron schedule for the scheduled hibernation job (e.g. "0 22 * * *").
   # Leave empty to disable the CronJob.
   cronSchedule: ""
+  # Idle window in minutes. Instances with no real usage for this long are hibernated.
+  # 0 disables idle hibernation. Any value > 0 also turns HIBERNATION_ENABLED on.
+  # Apart from 0, the effective minimum is 3: values of 1 or 2 are clamped up to 3.
+  idleMinutes: 0
 
 ingress:
   # -- Enable or disable Ingress for mcpx-webapp services


### PR DESCRIPTION
Enables signal-based idle hibernation without a cron schedule. HIBERNATION_ENABLED now flips on for cron or idle; idleMinutes > 0 also sets HIBERNATION_IDLE_MINUTES.